### PR TITLE
ci: add lockfile-lint and audit-ci steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
         type: string
         default: '12.18'
     docker:
-      - image: drptbl/docker-sec-tools:<<parameters.tag>>
+      - image: ghcr.io/synthetixio/docker-sec-tools/base:<<parameters.tag>>
 
 jobs:
   audit:


### PR DESCRIPTION
changes:
- added step for lockfile linting using [lockfile-lint](https://www.npmjs.com/package/lockfile-lint):
  - https://app.circleci.com/pipelines/github/Synthetixio/kwenta/15/workflows/3a1bf147-4be2-42bd-ae80-41defa17a651/jobs/44/parallel-runs/0/steps/0-102
  - it will fail if `package-lock.json` is not updated after dependency update/install
  - it will fail if following conditions are not met for dependencies: `--allowed-hosts npm github.com --allowed-schemes "https:" "git+https:" "github:"`
- added step for auditing dependencies using [audit-ci](https://www.npmjs.com/package/audit-ci):
  - https://app.circleci.com/pipelines/github/Synthetixio/kwenta/15/workflows/3a1bf147-4be2-42bd-ae80-41defa17a651/jobs/44/parallel-runs/0/steps/0-103
  - it will fail only on critical vulnerabilities
- both tools are included in `drptbl/docker-sec-tools` docker image which is used by this PR as `executor` => https://github.com/drptbl/docker-sec-tools
  - we should include this in to organization and push to (for example) Github Container Registry (ghcr) and refer it from here