### PR TITLE
feat: add IP whitelisting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1417,50 +1417,6 @@
 				"to-fast-properties": "^2.0.0"
 			}
 		},
-		"@chainlink/contracts-0.0.10": {
-			"version": "npm:@chainlink/contracts@0.0.10",
-			"resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
-			"integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
-			"requires": {
-				"@truffle/contract": "^4.2.6",
-				"ethers": "^4.0.45"
-			},
-			"dependencies": {
-				"ethers": {
-					"version": "4.0.48",
-					"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
-					"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
-					"optional": true,
-					"requires": {
-						"aes-js": "3.0.0",
-						"bn.js": "^4.4.0",
-						"elliptic": "6.5.3",
-						"hash.js": "1.1.3",
-						"js-sha3": "0.5.7",
-						"scrypt-js": "2.0.4",
-						"setimmediate": "1.0.4",
-						"uuid": "2.0.1",
-						"xmlhttprequest": "1.8.0"
-					}
-				},
-				"hash.js": {
-					"version": "1.1.3",
-					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-					"optional": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"minimalistic-assert": "^1.0.0"
-					}
-				},
-				"scrypt-js": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-					"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
-					"optional": true
-				}
-			}
-		},
 		"@chaitanyapotti/random-id": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@chaitanyapotti/random-id/-/random-id-1.0.3.tgz",
@@ -2122,7 +2078,7 @@
 			"dev": true,
 			"requires": {
 				"chai": "^4.2.0",
-				"jschardet": "2.2.1",
+				"jschardet": "^2.2.1",
 				"lodash": "^4.17.14",
 				"mocha": "^5.2.0",
 				"utf8": "^3.0.0"
@@ -10053,7 +10009,7 @@
 			"resolved": "https://registry.npmjs.org/eth-lattice-keyring/-/eth-lattice-keyring-0.2.5.tgz",
 			"integrity": "sha512-GzzukhB4H+8mPSF8QEcdX41OuuHlgyBmIy1OR8L77qAqUREwTXcAm+ytHr5uMe+NL/sDr79ZCDp3TIk4GI2Rcw==",
 			"requires": {
-				"gridplus-sdk": "0.6.1"
+				"gridplus-sdk": "^0.6.1"
 			}
 		},
 		"eth-lib": {
@@ -12831,11 +12787,19 @@
 				"loose-envify": "^1.0.0"
 			}
 		},
+		"ip-range-check": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/ip-range-check/-/ip-range-check-0.2.0.tgz",
+			"integrity": "sha512-oaM3l/3gHbLlt/tCWLvt0mj1qUaI+STuRFnUvARGCujK9vvU61+2JsDpmkMzR4VsJhuFXWWgeKKVnwwoFfzCqw==",
+			"dev": true,
+			"requires": {
+				"ipaddr.js": "^1.0.1"
+			}
+		},
 		"ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-			"optional": true
+			"integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
 		},
 		"is-accessor-descriptor": {
 			"version": "0.1.6",
@@ -15770,11 +15734,6 @@
 			"resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
 			"integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
 			"dev": true
-		},
-		"openzeppelin-solidity-2.3.0": {
-			"version": "npm:openzeppelin-solidity@2.3.0",
-			"resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
-			"integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
 		},
 		"optimized-images-loader": {
 			"version": "0.4.0",
@@ -19536,10 +19495,57 @@
 				"web3-utils": "1.2.2"
 			},
 			"dependencies": {
+				"@chainlink/contracts-0.0.10": {
+					"version": "npm:@chainlink/contracts@0.0.10",
+					"resolved": "https://registry.npmjs.org/@chainlink/contracts/-/contracts-0.0.10.tgz",
+					"integrity": "sha512-ok+ucSQ+3mrR+zjbi6zIrdd5M9XymcqVcnXGVyqBVRYZp97jS2/rt/glP320JmHxmi4pacgDOg0Ux11xIr1S8Q==",
+					"requires": {
+						"@truffle/contract": "^4.2.6",
+						"ethers": "^4.0.45"
+					}
+				},
 				"bn.js": {
 					"version": "4.11.8",
 					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
 					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+				},
+				"ethers": {
+					"version": "4.0.48",
+					"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+					"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+					"optional": true,
+					"requires": {
+						"aes-js": "3.0.0",
+						"bn.js": "^4.4.0",
+						"elliptic": "6.5.3",
+						"hash.js": "1.1.3",
+						"js-sha3": "0.5.7",
+						"scrypt-js": "2.0.4",
+						"setimmediate": "1.0.4",
+						"uuid": "2.0.1",
+						"xmlhttprequest": "1.8.0"
+					}
+				},
+				"hash.js": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+					"optional": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"openzeppelin-solidity-2.3.0": {
+					"version": "npm:openzeppelin-solidity@2.3.0",
+					"resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.3.0.tgz",
+					"integrity": "sha512-QYeiPLvB1oSbDt6lDQvvpx7k8ODczvE474hb2kLXZBPKMsxKT1WxTCHBYrCU7kS7hfAku4DcJ0jqOyL+jvjwQw=="
+				},
+				"scrypt-js": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+					"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+					"optional": true
 				},
 				"web3-utils": {
 					"version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
 		"imagemin-mozjpeg": "9.0.0",
 		"imagemin-optipng": "8.0.0",
 		"imagemin-svgo": "8.0.0",
+		"ip-range-check": "0.2.0",
 		"lint-staged": "10.0.10",
 		"prettier": "2.0.5",
 		"typescript": "4.0.5",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -3,9 +3,6 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Svg } from 'react-optimized-image';
 
-import { GetServerSideProps } from 'next';
-import { defaultServerSideProps } from 'utils/server';
-
 import AppLayout from 'sections/shared/Layout/AppLayout';
 
 import media from 'styles/media';
@@ -80,13 +77,5 @@ const Subtitle = styled.h2`
 		font-size: 14px;
 	`}
 `;
-
-export let getServerSideProps: GetServerSideProps;
-
-if (process.env.CF_IP) {
-	getServerSideProps = async (context) => {
-		return await defaultServerSideProps(context);
-	};
-}
 
 export default NotFoundPage;

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -3,6 +3,9 @@ import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 import { Svg } from 'react-optimized-image';
 
+import { GetServerSideProps } from 'next';
+import { defaultServerSideProps } from 'utils/server';
+
 import AppLayout from 'sections/shared/Layout/AppLayout';
 
 import media from 'styles/media';
@@ -77,5 +80,13 @@ const Subtitle = styled.h2`
 		font-size: 14px;
 	`}
 `;
+
+export let getServerSideProps: GetServerSideProps;
+
+if (process.env.CF_IP) {
+	getServerSideProps = async (context) => {
+		return await defaultServerSideProps(context);
+	};
+}
 
 export default NotFoundPage;

--- a/pages/dashboard/[[...tab]].tsx
+++ b/pages/dashboard/[[...tab]].tsx
@@ -84,8 +84,12 @@ const RightContainer = styled(FlexDivCol)`
 	margin-left: 20px;
 `;
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-	return await defaultServerSideProps(context);
-};
+export let getServerSideProps: GetServerSideProps;
+
+if (process.env.CF_IP) {
+	getServerSideProps = async (context) => {
+		return await defaultServerSideProps(context);
+	};
+}
 
 export default DashboardPage;

--- a/pages/dashboard/[[...tab]].tsx
+++ b/pages/dashboard/[[...tab]].tsx
@@ -3,6 +3,9 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 
+import { GetServerSideProps } from 'next';
+import { defaultServerSideProps } from 'utils/server';
+
 import { FlexDiv, FlexDivCol, PageContent, MobileContainerMixin } from 'styles/common';
 
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
@@ -80,5 +83,9 @@ const RightContainer = styled(FlexDivCol)`
 	position: relative;
 	margin-left: 20px;
 `;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+	return await defaultServerSideProps(context);
+};
 
 export default DashboardPage;

--- a/pages/exchange/[[...market]].tsx
+++ b/pages/exchange/[[...market]].tsx
@@ -200,8 +200,12 @@ const SliderContentSpacer = styled.div`
 	height: 16px;
 `;
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-	return await defaultServerSideProps(context);
-};
+export let getServerSideProps: GetServerSideProps;
+
+if (process.env.CF_IP) {
+	getServerSideProps = async (context) => {
+		return await defaultServerSideProps(context);
+	};
+}
 
 export default ExchangePage;

--- a/pages/exchange/[[...market]].tsx
+++ b/pages/exchange/[[...market]].tsx
@@ -4,6 +4,9 @@ import styled from 'styled-components';
 import Slider from 'react-slick';
 import { Svg } from 'react-optimized-image';
 
+import { GetServerSideProps } from 'next';
+import { defaultServerSideProps } from 'utils/server';
+
 import ArrowsIcon from 'assets/svg/app/arrows.svg';
 
 import AppLayout from 'sections/shared/Layout/AppLayout';
@@ -196,5 +199,9 @@ const SliderContent = styled.div``;
 const SliderContentSpacer = styled.div`
 	height: 16px;
 `;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+	return await defaultServerSideProps(context);
+};
 
 export default ExchangePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -65,8 +65,12 @@ const LightContainer = styled.div`
 	padding: 0 20px;
 `;
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-	return await defaultServerSideProps(context);
-};
+export let getServerSideProps: GetServerSideProps;
+
+if (process.env.CF_IP) {
+	getServerSideProps = async (context) => {
+		return await defaultServerSideProps(context);
+	};
+}
 
 export default HomePage;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -3,6 +3,9 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
+import { GetServerSideProps } from 'next';
+import { defaultServerSideProps } from 'utils/server';
+
 import HomeLayout from 'sections/shared/Layout/HomeLayout';
 
 import Hero from 'sections/homepage/Hero';
@@ -61,5 +64,9 @@ const LightContainer = styled.div`
 	background: ${(props) => props.theme.colors.elderberry};
 	padding: 0 20px;
 `;
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+	return await defaultServerSideProps(context);
+};
 
 export default HomePage;

--- a/utils/server.ts
+++ b/utils/server.ts
@@ -1,0 +1,25 @@
+import { GetServerSideProps } from 'next';
+import ipRangeCheck from 'ip-range-check';
+
+export const defaultServerSideProps: GetServerSideProps = async (context) => {
+	if (process.env.CF_IP) {
+		const allowedIps = JSON.parse(`[${process.env.CF_IP}]`);
+		const ip = context.req.headers['x-forwarded-for'] || context.req.connection.remoteAddress;
+		if (typeof ip === 'string' && !ipRangeCheck(ip, allowedIps)) {
+			context.res.statusCode = 403;
+			context.res.end('Your IP is not whitelisted.');
+			return { props: {} };
+		} else {
+			const props = await getProps();
+			return props;
+		}
+	} else {
+		const props = await getProps();
+		return props;
+	}
+	async function getProps() {
+		return {
+			props: {},
+		};
+	}
+};


### PR DESCRIPTION
I had to add whitelisting to each page separately. I couldn't find a way to set `getServerSideProps` globally.

It will work only if `CF_IP` variable is present and it's only available on Vercel (production) deployment which means that IP whitelisting won't be turned on for any other env (IPFS, staging, localhost).