### PR TITLE
fix: deprecate `window.web3` and use `@metamask/detect-provider` for provider detection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2357,6 +2357,11 @@
 			"resolved": "https://registry.npmjs.org/@ledgerhq/logs/-/logs-5.26.0.tgz",
 			"integrity": "sha512-/3EKvS9eHzKl9Om+t//SPnzJaahIoVIUlozLMSarINyO7SSh174kxl3jTNHBl7dLxvkQyDDs5imLvP04ohlQaw=="
 		},
+		"@metamask/detect-provider": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@metamask/detect-provider/-/detect-provider-1.2.0.tgz",
+			"integrity": "sha512-ocA76vt+8D0thgXZ7LxFPyqw3H7988qblgzddTDA6B8a/yU0uKV42QR/DhA+Jh11rJjxW0jKvwb5htA6krNZDQ=="
+		},
 		"@microsoft/eslint-formatter-sarif": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@microsoft/eslint-formatter-sarif/-/eslint-formatter-sarif-2.1.5.tgz",
@@ -2364,7 +2369,7 @@
 			"dev": true,
 			"requires": {
 				"chai": "^4.2.0",
-				"jschardet": "2.2.1",
+				"jschardet": "^2.2.1",
 				"lodash": "^4.17.14",
 				"mocha": "^5.2.0",
 				"utf8": "^3.0.0"
@@ -11893,7 +11898,7 @@
 			"resolved": "https://registry.npmjs.org/eth-lattice-keyring/-/eth-lattice-keyring-0.2.5.tgz",
 			"integrity": "sha512-GzzukhB4H+8mPSF8QEcdX41OuuHlgyBmIy1OR8L77qAqUREwTXcAm+ytHr5uMe+NL/sDr79ZCDp3TIk4GI2Rcw==",
 			"requires": {
-				"gridplus-sdk": "0.6.1"
+				"gridplus-sdk": "^0.6.1"
 			}
 		},
 		"eth-lib": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 	},
 	"dependencies": {
 		"@artsy/fresnel": "1.3.0",
+		"@metamask/detect-provider": "1.2.0",
 		"@reach/accordion": "0.11.2",
 		"@reach/dialog": "0.11.0",
 		"@reach/tabs": "0.11.2",

--- a/utils/network.ts
+++ b/utils/network.ts
@@ -1,16 +1,19 @@
-import { DEFAULT_GAS_BUFFER, DEFAULT_NETWORK_ID } from 'constants/defaults';
+import detectEthereumProvider from '@metamask/detect-provider';
 import { NetworkId } from '@synthetixio/js';
+
+import { DEFAULT_GAS_BUFFER, DEFAULT_NETWORK_ID } from 'constants/defaults';
 import { GWEI_UNIT } from 'constants/network';
+
+type EthereumProvider = {
+	isMetaMask: boolean;
+	networkVersion: string;
+};
 
 export async function getDefaultNetworkId(): Promise<NetworkId> {
 	try {
-		if (window.web3?.eth?.net) {
-			const networkId = await window.web3.eth.net.getId();
-			return Number(networkId);
-		} else if (window.web3?.version?.network) {
-			return Number(window.web3.version.network);
-		} else if (window.ethereum?.networkVersion) {
-			return Number(window.ethereum?.networkVersion);
+		const provider = (await detectEthereumProvider()) as EthereumProvider;
+		if (provider) {
+			return Number(provider.networkVersion);
 		}
 		return DEFAULT_NETWORK_ID;
 	} catch (e) {


### PR DESCRIPTION
Remove `window.web3` as its deprecated and use MetaMask ethereum provider detector - https://github.com/MetaMask/detect-provider