### PR TITLE
Bumps bnc-onboard to v1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"axios": "0.21.1",
 		"bignumber.js": "9.0.0",
 		"bnc-notify": "1.5.0",
-		"bnc-onboard": "1.14.0",
+		"bnc-onboard": "1.19.0",
 		"date-fns": "2.15.0",
 		"ethers": "5.0.8",
 		"i18next": "19.7.0",


### PR DESCRIPTION
This is just a simple module bump to fix your [Lattice1](https://gridplus.io/lattice) integration, which is currently broken on the live site. We underwent some breaking changes on the Lattice1 firmware side, which were captured in `bnc-onboard` updates.

I think you may want to close this and bump the module yourself, so I mainly just wanted to put this in front of you.