### PR TITLE
feat: add shorting c-ratio

### DIFF
--- a/sections/exchange/FooterCard/common.tsx
+++ b/sections/exchange/FooterCard/common.tsx
@@ -55,4 +55,5 @@ export type SubmissionDisabledReason =
 	| 'approve-balancer'
 	| 'approving'
 	| 'claim'
-	| 'submitting';
+	| 'submitting'
+	| 'c-ratio-too-low';

--- a/sections/exchange/TradeCard/CurrencyCard/CurrencyCard.tsx
+++ b/sections/exchange/TradeCard/CurrencyCard/CurrencyCard.tsx
@@ -70,52 +70,54 @@ const CurrencyCard: FC<CurrencyCardProps> = ({
 	const hasCurrencySelectCallback = onCurrencySelect != null;
 
 	return (
-		<Card className="currency-card" {...rest}>
-			<StyledCardBody>
+		<Card className={`currency-card currency-card-${side}`} {...rest}>
+			<StyledCardBody className="currency-card-body">
 				<LabelContainer data-testid="destination">{label}</LabelContainer>
-				<CurrencyContainer>
-					<CurrencySelector
-						currencyKeySelected={currencyKeySelected}
-						onClick={hasCurrencySelectCallback ? onCurrencySelect : undefined}
-						role="button"
-						data-testid="currency-selector"
-					>
-						{currencyKey ?? (
-							<CapitalizedText>
-								{t('exchange.currency-card.currency-selector.no-value')}
-							</CapitalizedText>
-						)}{' '}
-						{hasCurrencySelectCallback && <Svg src={CaretDownIcon} />}
-					</CurrencySelector>
-					{currencyKeySelected && (
-						<CurrencyAmountContainer>
-							<CurrencyAmount
-								value={amount}
-								onChange={(_, value) => onAmountChange(value)}
-								placeholder="0"
-								data-testid="currency-amount"
-							/>
-							<CurrencyAmountValue data-testid="amount-value">
-								{tradeAmount != null
-									? formatCurrency(selectedPriceCurrency.name, tradeAmount, {
-											sign: selectedPriceCurrency.sign,
-									  })
-									: null}
-							</CurrencyAmountValue>
-						</CurrencyAmountContainer>
-					)}
-				</CurrencyContainer>
-				<WalletBalanceContainer>
-					<WalletBalanceLabel>{t('exchange.currency-card.wallet-balance')}</WalletBalanceLabel>
-					<WalletBalance
-						onClick={hasWalletBalance ? onBalanceClick : undefined}
-						insufficientBalance={insufficientBalance}
-						data-testid="wallet-balance"
-					>
-						{/* @ts-ignore */}
-						{hasWalletBalance ? formatCurrency(currencyKey, walletBalance) : NO_VALUE}
-					</WalletBalance>
-				</WalletBalanceContainer>
+				<CurrencyWalletBalanceContainer className="currency-wallet-container">
+					<CurrencyContainer className="currency-container">
+						<CurrencySelector
+							currencyKeySelected={currencyKeySelected}
+							onClick={hasCurrencySelectCallback ? onCurrencySelect : undefined}
+							role="button"
+							data-testid="currency-selector"
+						>
+							{currencyKey ?? (
+								<CapitalizedText>
+									{t('exchange.currency-card.currency-selector.no-value')}
+								</CapitalizedText>
+							)}{' '}
+							{hasCurrencySelectCallback && <Svg src={CaretDownIcon} />}
+						</CurrencySelector>
+						{currencyKeySelected && (
+							<CurrencyAmountContainer className="currency-amount-container">
+								<CurrencyAmount
+									value={amount}
+									onChange={(_, value) => onAmountChange(value)}
+									placeholder="0"
+									data-testid="currency-amount"
+								/>
+								<CurrencyAmountValue data-testid="amount-value">
+									{tradeAmount != null
+										? formatCurrency(selectedPriceCurrency.name, tradeAmount, {
+												sign: selectedPriceCurrency.sign,
+										  })
+										: null}
+								</CurrencyAmountValue>
+							</CurrencyAmountContainer>
+						)}
+					</CurrencyContainer>
+					<WalletBalanceContainer>
+						<WalletBalanceLabel>{t('exchange.currency-card.wallet-balance')}</WalletBalanceLabel>
+						<WalletBalance
+							onClick={hasWalletBalance ? onBalanceClick : undefined}
+							insufficientBalance={insufficientBalance}
+							data-testid="wallet-balance"
+						>
+							{/* @ts-ignore */}
+							{hasWalletBalance ? formatCurrency(currencyKey, walletBalance) : NO_VALUE}
+						</WalletBalance>
+					</WalletBalanceContainer>
+				</CurrencyWalletBalanceContainer>
 			</StyledCardBody>
 		</Card>
 	);
@@ -130,6 +132,8 @@ const LabelContainer = styled.div`
 	padding-bottom: 2px;
 	text-transform: capitalize;
 `;
+
+const CurrencyWalletBalanceContainer = styled.div``;
 
 const CurrencyContainer = styled(FlexDivRowCentered)`
 	padding-bottom: 6px;
@@ -173,7 +177,7 @@ const CurrencySelector = styled.div<{
 const CurrencyAmountContainer = styled.div`
 	background-color: ${(props) => props.theme.colors.black};
 	border-radius: 4px;
-	width: 70%;
+	width: 100%;
 `;
 
 const CurrencyAmount = styled(NumericInput)`

--- a/sections/shorting/ShortingCard/ShortingCard.tsx
+++ b/sections/shorting/ShortingCard/ShortingCard.tsx
@@ -5,13 +5,14 @@ import { SYNTHS_MAP } from 'constants/currency';
 
 import media from 'styles/media';
 
+import CRatioSelector from './components/CRatioSelector';
+
 import useShort from '../hooks/useShort';
 
 const ShortingCard: FC = () => {
 	const { quoteCurrencyCard, baseCurrencyCard, footerCard } = useShort({
 		defaultBaseCurrencyKey: SYNTHS_MAP.sETH,
 		defaultQuoteCurrencyKey: SYNTHS_MAP.sUSD,
-		shortRatio: 2,
 	});
 
 	return (
@@ -20,6 +21,9 @@ const ShortingCard: FC = () => {
 				<ExchangeCards>
 					{quoteCurrencyCard}
 					{baseCurrencyCard}
+					<CRatioSelectorContainer>
+						<CRatioSelector />
+					</CRatioSelectorContainer>
 				</ExchangeCards>
 				<ExchangeFooter>{footerCard}</ExchangeFooter>
 			</ConvertContainer>
@@ -34,6 +38,24 @@ const Container = styled.div`
 
 const ConvertContainer = styled.div``;
 
+const CRatioSelectorContainer = styled.div`
+	position: absolute;
+	padding: 6px;
+	border-radius: 4px;
+	background: ${(props) => props.theme.colors.elderberry};
+	border: 2px solid ${(props) => props.theme.colors.black};
+	left: 50%;
+	transform: translate(-50%, -50%);
+	margin-left: -14px;
+	width: 70px;
+	top: 50%;
+	margin-top: -3px;
+	${media.lessThan('md')`
+		margin-left: 0;
+		margin-top: -14px;
+	`}
+`;
+
 export const ExchangeFooter = styled.div`
 	.footer-card {
 		max-width: 1000px;
@@ -41,6 +63,7 @@ export const ExchangeFooter = styled.div`
 `;
 
 export const ExchangeCards = styled.div`
+	position: relative;
 	display: grid;
 	grid-template-columns: auto auto;
 	grid-gap: 2px;
@@ -55,7 +78,24 @@ export const ExchangeCards = styled.div`
 
 	.currency-card {
 		padding: 0 14px;
-		width: 100%;
+		${media.lessThan('md')`
+			padding: unset;
+		`}
+		.currency-wallet-container {
+			width: 90%;
+			${media.lessThan('md')`
+				width: 100%;
+			`}
+		}
+	}
+	.currency-card-base {
+		.currency-card-body {
+			position: relative;
+			left: 30px;
+			${media.lessThan('md')`
+				left: unset;
+			`}
+		}
 	}
 `;
 

--- a/sections/shorting/ShortingCard/components/CRatioSelector/CRatioSelector.tsx
+++ b/sections/shorting/ShortingCard/components/CRatioSelector/CRatioSelector.tsx
@@ -1,0 +1,146 @@
+import { FC, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled, { css } from 'styled-components';
+import { useRecoilState } from 'recoil';
+
+import { customShortCRatioState, shortCRatioState } from 'store/ui';
+import { formatPercent } from 'utils/formatters/number';
+
+import { Svg } from 'react-optimized-image';
+
+import {
+	NumericValue,
+	SolidTooltip,
+	SolidTooltipContent,
+	SolidTooltipCustomValue,
+	SolidTooltipCustomValueContainer,
+	SolidTooltipItemButton,
+} from 'styles/common';
+
+import CaretDownIcon from 'assets/svg/app/caret-down.svg';
+
+export type ShortCRatioLevel = 'safe' | 'safeMax' | 'highRisk';
+
+export const SHORT_C_RATIO: Record<ShortCRatioLevel, number> = {
+	safe: 200,
+	safeMax: 165,
+	highRisk: 155,
+};
+
+export const shortCRatios = Object.entries(SHORT_C_RATIO) as [ShortCRatioLevel, number][];
+
+type CRatioSelectorProps = {};
+
+export const CRatioSelector: FC<CRatioSelectorProps> = () => {
+	const { t } = useTranslation();
+
+	const [selectedShortCRatio, setSelectedShortCRatio] = useRecoilState(shortCRatioState);
+	const [customShortCRatio, setCustomShortCRatio] = useRecoilState(customShortCRatioState);
+	const [tooltipOpened, setTooltipOpened] = useState<boolean>(false);
+
+	const hasCustomShortCRatio = useMemo(() => customShortCRatio !== '', [customShortCRatio]);
+
+	const shortCRatio = useMemo(
+		() => (hasCustomShortCRatio ? Number(customShortCRatio) : selectedShortCRatio),
+		[hasCustomShortCRatio, selectedShortCRatio, customShortCRatio]
+	);
+
+	const formattedShortCRatio = useMemo(() => formatPercent(shortCRatio / 100, { minDecimals: 0 }), [
+		shortCRatio,
+	]);
+
+	const shortCRatioTooLow = useMemo(() => shortCRatio < SHORT_C_RATIO.highRisk, [shortCRatio]);
+
+	return (
+		<Container>
+			<Label>{t('shorting.common.cRatio')}</Label>
+			<StyledSolidTooltip
+				onShow={() => setTooltipOpened(true)}
+				onHide={() => setTooltipOpened(false)}
+				offset={[0, 20]}
+				content={
+					<SolidTooltipContent>
+						<SolidTooltipCustomValueContainer>
+							<SolidTooltipCustomValue
+								value={customShortCRatio}
+								onChange={(_, value) => setCustomShortCRatio(value)}
+								placeholder={t('common.custom')}
+							/>
+						</SolidTooltipCustomValueContainer>
+						{shortCRatios.map(([shortCRatioLevel, shortCRatioValue]) => (
+							<SolidTooltipItemButton
+								key={shortCRatioLevel}
+								variant="select"
+								onClick={() => {
+									setCustomShortCRatio('');
+									setSelectedShortCRatio(shortCRatioValue);
+								}}
+								isActive={hasCustomShortCRatio ? false : shortCRatioValue === selectedShortCRatio}
+							>
+								<span>{t(`shorting.c-ratio.${shortCRatioLevel}`)}</span>
+								<NumericValue>
+									{formatPercent(shortCRatioValue / 100, { minDecimals: 0 })}
+								</NumericValue>
+							</SolidTooltipItemButton>
+						))}
+					</SolidTooltipContent>
+				}
+			>
+				<DropdownSelection
+					role="button"
+					tooltipOpened={tooltipOpened}
+					shortCRatioTooLow={shortCRatioTooLow}
+				>
+					{formattedShortCRatio}{' '}
+					<Svg src={CaretDownIcon} viewBox={`0 0 ${CaretDownIcon.width} ${CaretDownIcon.height}`} />
+				</DropdownSelection>
+			</StyledSolidTooltip>
+		</Container>
+	);
+};
+
+const StyledSolidTooltip = styled(SolidTooltip)`
+	width: 130px;
+`;
+
+const Container = styled.div`
+	text-align: center;
+	overflow: hidden;
+	text-overflow: ellipsis;
+`;
+
+const Label = styled.div`
+	color: ${(props) => props.theme.colors.silver};
+`;
+
+export const DropdownSelection = styled.span<{
+	tooltipOpened: boolean;
+	shortCRatioTooLow: boolean;
+}>`
+	user-select: none;
+	display: inline-flex;
+	align-items: center;
+	font-family: ${(props) => props.theme.fonts.bold};
+	padding-left: 5px;
+	cursor: pointer;
+	color: ${(props) => props.theme.colors.white};
+	text-transform: uppercase;
+	svg {
+		color: ${(props) => props.theme.colors.goldColors.color3};
+		width: 10px;
+		margin-left: 5px;
+		transition: transform 0.2s ease-in-out;
+		${(props) =>
+			props.tooltipOpened &&
+			css`
+				transform: rotate(-180deg);
+			`};
+	}
+	${(props) =>
+		props.shortCRatioTooLow &&
+		css`
+			color: ${(props) => props.theme.colors.red};
+		`}
+`;
+
+export default CRatioSelector;

--- a/sections/shorting/ShortingCard/components/CRatioSelector/index.ts
+++ b/sections/shorting/ShortingCard/components/CRatioSelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from './CRatioSelector';

--- a/store/ui/index.ts
+++ b/store/ui/index.ts
@@ -1,6 +1,8 @@
 import { atom } from 'recoil';
 
 import { DEFAULT_SORT_OPTION } from 'sections/dashboard/TrendingSynths/constants';
+import { SHORT_C_RATIO } from 'sections/shorting/ShortingCard/components/CRatioSelector/CRatioSelector';
+
 import { getUIKey } from '../utils';
 
 export const hasOrdersNotificationState = atom<boolean>({
@@ -11,4 +13,14 @@ export const hasOrdersNotificationState = atom<boolean>({
 export const trendingSynthsOptionState = atom<typeof DEFAULT_SORT_OPTION>({
 	key: getUIKey('trendingSynthsOption'),
 	default: DEFAULT_SORT_OPTION,
+});
+
+export const shortCRatioState = atom<number>({
+	key: getUIKey('shortCRatio'),
+	default: SHORT_C_RATIO.safe,
+});
+
+export const customShortCRatioState = atom<string>({
+	key: getUIKey('customShortCRatio'),
+	default: '',
 });

--- a/styles/common.tsx
+++ b/styles/common.tsx
@@ -1,4 +1,6 @@
 import Tippy from '@tippyjs/react';
+import Button from 'components/Button';
+import NumericInput from 'components/Input/NumericInput';
 import { zIndex } from 'constants/ui';
 import styled, { css, keyframes } from 'styled-components';
 
@@ -209,4 +211,41 @@ export const Tooltip = styled(Tippy)`
 	background: ${(props) => props.theme.colors.elderberry};
 	border: 0.5px solid ${(props) => props.theme.colors.navy};
 	border-radius: 4px;
+`;
+
+export const SolidTooltip = styled(Tooltip).attrs({
+	trigger: 'click',
+	arrow: false,
+	interactive: true,
+})`
+	width: 150px;
+	.tippy-content {
+		padding: 0;
+	}
+`;
+
+export const SolidTooltipContent = styled.div`
+	padding: 16px 0 8px 0;
+`;
+
+export const SolidTooltipCustomValueContainer = styled.div`
+	margin: 0 10px 5px 10px;
+`;
+
+export const SolidTooltipCustomValue = styled(NumericInput)`
+	width: 100%;
+	border: 0;
+	font-size: 12px;
+	::placeholder {
+		font-family: ${(props) => props.theme.fonts.mono};
+	}
+`;
+
+export const SolidTooltipItemButton = styled(Button)`
+	width: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding-left: 10px;
+	padding-right: 10px;
 `;

--- a/translations/en.json
+++ b/translations/en.json
@@ -189,6 +189,7 @@
 			"button": {
 				"approve": "approve",
 				"approving": "approving",
+				"c-ratio-too-low": "C-Ratio is too low",
 				"fee-reclaim-period": "fee reclaim period",
 				"insufficient-balance": "insufficient balance",
 				"enter-amount": "enter amount",
@@ -306,7 +307,13 @@
 			"collateral": "collateral",
 			"posting": "posting",
 			"shorting": "shorting",
-			"interestRate": "Interest Rate"
+			"interestRate": "Interest Rate",
+			"cRatio": "C-Ratio"
+		},
+		"c-ratio": {
+			"safe": "safe",
+			"safeMax": "safe max",
+			"highRisk": "high risk"
 		},
 		"rewards": {
 			"available": "Available Rewards",


### PR DESCRIPTION
Altho this is a "c-ratio" I am storing it in percentage (because of the custom input).
There are some edge cases that I did not handle in the UI (like input too long, etc) - can be done later.

Tested on both desktop/mobile.

"C-Ratio too low" will be disabled on the button for now (as a disabled state) + the ratio becomes red.. this is just a quick win for now as I progress with other things.