### PR TITLE
fix: added check for window.ethereum

### DIFF
--- a/utils/network.ts
+++ b/utils/network.ts
@@ -11,9 +11,11 @@ type EthereumProvider = {
 
 export async function getDefaultNetworkId(): Promise<NetworkId> {
 	try {
-		const provider = (await detectEthereumProvider()) as EthereumProvider;
-		if (provider) {
-			return Number(provider.networkVersion);
+		if (window.ethereum) {
+			const provider = (await detectEthereumProvider()) as EthereumProvider;
+			if (provider) {
+				return Number(provider.networkVersion);
+			}
 		}
 		return DEFAULT_NETWORK_ID;
 	} catch (e) {


### PR DESCRIPTION
Added a check for `window.ethereum` in `getDefaultNetworkId()` because "Connect Wallet" will not work until a provider is determined

![image](https://user-images.githubusercontent.com/4015977/109719799-2f4f8f80-7b77-11eb-9989-8984ed1288d1.png)

Fixes #254 