### PR TITLE
feat: shorting stats

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -56,6 +56,7 @@ export const QUERY_KEYS = {
 		ShortPositionPnL: (loanId: string) => ['collateral', 'short', 'position', 'pnl', loanId],
 		ShortRewards: (currencyKey: string) => ['collateral', 'short', 'rewards', currencyKey],
 		ShortRate: (currencyKey: string) => ['collateral', 'short', 'rate', currencyKey],
+		ShortStats: (currencyKey: string) => ['collateral', 'short', 'stats', currencyKey],
 	},
 	Trades: {
 		AllTrades: ['trades', 'allTrades'],

--- a/constants/ui.ts
+++ b/constants/ui.ts
@@ -1,4 +1,5 @@
 export const HEADER_HEIGHT = '45px';
+export const SPACING_FROM_HEADER = '80px';
 
 export enum zIndex {
 	BASE = 1,

--- a/pages/dashboard/[[...tab]].tsx
+++ b/pages/dashboard/[[...tab]].tsx
@@ -3,11 +3,16 @@ import Head from 'next/head';
 import { useTranslation } from 'react-i18next';
 import { useRecoilValue } from 'recoil';
 
-import { FlexDiv, FlexDivCol, PageContent, MobileContainerMixin } from 'styles/common';
-
 import { DesktopOnlyView, MobileOrTabletView } from 'components/Media';
 
-import { BottomShadow } from 'styles/common';
+import {
+	BottomShadow,
+	MainContent,
+	RightSideContent,
+	FullHeightContainer,
+	PageContent,
+	MobileContainerMixin,
+} from 'styles/common';
 
 import AppLayout from 'sections/shared/Layout/AppLayout';
 import DashboardCard from 'sections/dashboard/DashboardCard';
@@ -31,13 +36,13 @@ const DashboardPage = () => {
 			<AppLayout>
 				<PageContent>
 					<DesktopOnlyView>
-						<Container>
-							<LeftContainer>{activeView}</LeftContainer>
-							<RightContainer>
+						<FullHeightContainer>
+							<MainContent>{activeView}</MainContent>
+							<RightSideContent>
 								<TrendingSynths />
-							</RightContainer>
+							</RightSideContent>
 							<BottomShadow />
-						</Container>
+						</FullHeightContainer>
 					</DesktopOnlyView>
 					<MobileOrTabletView>
 						<MobileContainer>{activeView}</MobileContainer>
@@ -48,37 +53,9 @@ const DashboardPage = () => {
 	);
 };
 
-const SPACING_FROM_HEADER = '80px';
-
 const MobileContainer = styled.div`
 	${MobileContainerMixin};
 	padding-top: 90px;
-`;
-
-const Container = styled(FlexDiv)`
-	justify-content: space-between;
-	width: 100%;
-	flex-grow: 1;
-	height: 100vh;
-	position: relative;
-`;
-
-const LeftContainer = styled(FlexDivCol)`
-	flex-grow: 1;
-	max-width: 1000px;
-	position: relative;
-	overflow: auto;
-	margin: ${SPACING_FROM_HEADER} auto 0 auto;
-`;
-
-const RightContainer = styled(FlexDivCol)`
-	width: 340px;
-	background-color: ${(props) => props.theme.colors.elderberry};
-	padding: ${SPACING_FROM_HEADER} 0 5px 0;
-	margin-right: -20px;
-	flex-shrink: 0;
-	position: relative;
-	margin-left: 20px;
 `;
 
 export default DashboardPage;

--- a/pages/shorting/index.tsx
+++ b/pages/shorting/index.tsx
@@ -7,12 +7,21 @@ import { useRecoilValue } from 'recoil';
 import ShortingCard from 'sections/shorting/ShortingCard';
 import ShortingHistory from 'sections/shorting/ShortingHistory';
 import ShortingRewards from 'sections/shorting/ShortingRewards';
+import ShortingStats from 'sections/shorting/ShortingStats';
+import { SYNTHS_TO_SHORT } from 'sections/shorting/constants';
 
 import AppLayout from 'sections/shared/Layout/AppLayout';
-import { GridDiv, PageContent } from 'styles/common';
+
+import {
+	GridDiv,
+	PageContent,
+	MainContent,
+	RightSideContent,
+	FullHeightContainer,
+} from 'styles/common';
 import media from 'styles/media';
 
-import { SYNTHS_MAP } from 'constants/currency';
+import { DesktopOnlyView } from 'components/Media';
 
 import { isWalletConnectedState } from 'store/wallet';
 
@@ -26,25 +35,28 @@ const Shorting: FC = () => {
 				<title>{t('shorting.page-title')}</title>
 			</Head>
 			<AppLayout>
-				<StyledPageContent>
-					<ShortingCard />
-					<ShortingRewardsContainer>
-						<ShortingRewards currencyKey={SYNTHS_MAP.sETH} />
-						<ShortingRewards currencyKey={SYNTHS_MAP.sBTC} />
-					</ShortingRewardsContainer>
-					{isWalletConnected && <ShortingHistory />}
-				</StyledPageContent>
+				<PageContent>
+					<FullHeightContainer>
+						<MainContent>
+							<ShortingCard />
+							<ShortingRewardsContainer>
+								{SYNTHS_TO_SHORT.map((currencyKey) => (
+									<ShortingRewards key={currencyKey} currencyKey={currencyKey} />
+								))}
+							</ShortingRewardsContainer>
+							{isWalletConnected && <ShortingHistory />}
+						</MainContent>
+						<DesktopOnlyView>
+							<StyledRightSideContent>
+								<ShortingStats />
+							</StyledRightSideContent>
+						</DesktopOnlyView>
+					</FullHeightContainer>
+				</PageContent>
 			</AppLayout>
 		</>
 	);
 };
-
-const StyledPageContent = styled(PageContent)`
-	padding-top: 55px;
-	${media.greaterThan('md')`
-		max-width: 1000px;
-	`}
-`;
 
 const ShortingRewardsContainer = styled(GridDiv)`
 	grid-gap: 24px;
@@ -54,6 +66,11 @@ const ShortingRewardsContainer = styled(GridDiv)`
 		/* TODO: this is kinda ugly, and basically undoing the spacing that comes from the TradeSummaryCard */
 		margin-top: -62px;
 	`}
+`;
+
+const StyledRightSideContent = styled(RightSideContent)`
+	padding-left: 32px;
+	padding-right: 32px;
 `;
 
 export default Shorting;

--- a/queries/collateral/useCollateralShortStats.ts
+++ b/queries/collateral/useCollateralShortStats.ts
@@ -1,0 +1,44 @@
+import { useQuery, QueryConfig } from 'react-query';
+import { useRecoilValue } from 'recoil';
+import { ethers } from 'ethers';
+import BigNumber from 'bignumber.js';
+import zipObject from 'lodash/zipObject';
+
+import { CurrencyKey } from 'constants/currency';
+import { appReadyState } from 'store/app';
+
+import QUERY_KEYS from 'constants/queryKeys';
+
+import synthetix from 'lib/synthetix';
+import { toBigNumber } from 'utils/formatters/number';
+
+const useCollateralShortStats = (
+	currencyKeys: CurrencyKey[],
+	options?: QueryConfig<Record<CurrencyKey, BigNumber>>
+) => {
+	const isAppReady = useRecoilValue(appReadyState);
+
+	return useQuery<Record<CurrencyKey, BigNumber>>(
+		QUERY_KEYS.Collateral.ShortStats(currencyKeys.join('|')),
+		async () => {
+			const shorts = (await Promise.all(
+				currencyKeys.map((currencyKey) =>
+					synthetix.js!.contracts.CollateralManager.short(
+						ethers.utils.formatBytes32String(currencyKey)
+					)
+				)
+			)) as ethers.BigNumber[];
+
+			return zipObject(
+				currencyKeys,
+				shorts.map((short) => toBigNumber(ethers.utils.formatEther(short)))
+			);
+		},
+		{
+			enabled: isAppReady,
+			...options,
+		}
+	);
+};
+
+export default useCollateralShortStats;

--- a/sections/shorting/ShortingStats/ShortingStats.tsx
+++ b/sections/shorting/ShortingStats/ShortingStats.tsx
@@ -1,0 +1,177 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import mapValues from 'lodash/mapValues';
+import reduce from 'lodash/reduce';
+
+import useCollateralShortStats from 'queries/collateral/useCollateralShortStats';
+import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
+
+import { NumericValue, Table } from 'styles/common';
+
+import Currency from 'components/Currency';
+
+import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
+
+import { CRYPTO_CURRENCY_MAP } from 'constants/currency';
+import { NO_VALUE } from 'constants/placeholder';
+
+import { formatCurrency, formatPercent, toBigNumber, zeroBN } from 'utils/formatters/number';
+import { WEEKS_IN_YEAR } from 'utils/formatters/date';
+
+import { SYNTHS_TO_SHORT } from '../constants';
+
+const WEEKLY_SNX_REWARDS = toBigNumber(8000);
+
+const ShortingStats = () => {
+	const { t } = useTranslation();
+	const { selectPriceCurrencyRate, selectedPriceCurrency } = useSelectedPriceCurrency();
+
+	const exchangeRatesQuery = useExchangeRatesQuery();
+	const exchangeRates = useMemo(
+		() => (exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null),
+		[exchangeRatesQuery.isSuccess, exchangeRatesQuery.data]
+	);
+
+	const collateralShortStatsQuery = useCollateralShortStats(SYNTHS_TO_SHORT);
+	const shortStats = useMemo(
+		() => (collateralShortStatsQuery.isSuccess ? collateralShortStatsQuery.data ?? null : null),
+		[collateralShortStatsQuery.isSuccess, collateralShortStatsQuery.data]
+	);
+
+	const shortStatsMap = useMemo(() => {
+		if (shortStats != null && exchangeRates != null && selectPriceCurrencyRate != null) {
+			return mapValues(shortStats, (shortStat, currencyKey) => {
+				const openInterest = shortStat
+					.multipliedBy(exchangeRates[currencyKey])
+					.dividedBy(selectPriceCurrencyRate);
+
+				const apr = WEEKLY_SNX_REWARDS.multipliedBy(exchangeRates[CRYPTO_CURRENCY_MAP.SNX])
+					.multipliedBy(WEEKS_IN_YEAR)
+					.dividedBy(openInterest);
+
+				return {
+					openInterest,
+					apr,
+					currencyKey,
+				};
+			});
+		}
+		return null;
+	}, [shortStats, exchangeRates, selectPriceCurrencyRate]);
+
+	const total = useMemo(() => {
+		if (shortStatsMap != null) {
+			return reduce(shortStatsMap, (sum, short) => sum.plus(short.openInterest), zeroBN);
+		}
+		return null;
+	}, [shortStatsMap]);
+
+	return (
+		<div>
+			<Title>{t('shorting.stats.title')}</Title>
+			<Table>
+				<thead>
+					<TableRowHead>
+						<TableCellHead>{t('shorting.stats.table.asset')}</TableCellHead>
+						<TableCellHead>{t('shorting.stats.table.apr')}</TableCellHead>
+						<TableCellHead>{t('shorting.stats.table.open-interest')}</TableCellHead>
+					</TableRowHead>
+				</thead>
+				<tbody>
+					{SYNTHS_TO_SHORT.map((currencyKey) => (
+						<TableRow key={currencyKey}>
+							<TableCell>
+								<StyledCurrencyName currencyKey={currencyKey} showIcon={true} />
+							</TableCell>
+							<TableCell>
+								<NumericValue>
+									{shortStatsMap != null && shortStatsMap[currencyKey] != null
+										? formatPercent(shortStatsMap[currencyKey].apr)
+										: NO_VALUE}
+								</NumericValue>
+							</TableCell>
+							<TableCell>
+								<NumericValue>
+									{shortStatsMap != null && shortStatsMap[currencyKey] != null
+										? formatCurrency(
+												selectedPriceCurrency.name,
+												shortStatsMap[currencyKey].openInterest,
+												{
+													sign: selectedPriceCurrency.sign,
+												}
+										  )
+										: NO_VALUE}
+								</NumericValue>
+							</TableCell>
+						</TableRow>
+					))}
+					<TableRow>
+						<TableCell colSpan={2}>
+							<TotalLabel>{t('shorting.stats.table.total')}</TotalLabel>
+						</TableCell>
+						<TableCell>
+							<NumericValue>
+								{total != null
+									? formatCurrency(selectedPriceCurrency.name, total, {
+											sign: selectedPriceCurrency.sign,
+									  })
+									: NO_VALUE}
+							</NumericValue>
+						</TableCell>
+					</TableRow>
+				</tbody>
+			</Table>
+		</div>
+	);
+};
+
+const Title = styled.div`
+	color: ${(props) => props.theme.colors.white};
+	font-family: ${(props) => props.theme.fonts.bold};
+	font-size: 14px;
+	text-transform: capitalize;
+	padding-bottom: 5px;
+`;
+
+const TableRow = styled.tr`
+	text-align: left;
+	height: 40px;
+	border-bottom: 1px solid ${(props) => props.theme.colors.navy};
+	&:last-child {
+		border-bottom: 0;
+	}
+`;
+
+const TableRowHead = styled(TableRow)``;
+
+const TableCell = styled.td`
+	color: ${(props) => props.theme.colors.white};
+	&:last-child {
+		text-align: right;
+	}
+`;
+
+const TableCellHead = styled.th`
+	text-transform: capitalize;
+	font-family: ${(props) => props.theme.fonts.bold};
+	&:last-child {
+		text-align: right;
+	}
+`;
+
+const StyledCurrencyName = styled(Currency.Name)`
+	.symbol {
+		font-size: 12px;
+		font-family: ${(props) => props.theme.fonts.regular};
+	}
+`;
+
+const TotalLabel = styled.span`
+	font-family: ${(props) => props.theme.fonts.regular};
+	color: ${(props) => props.theme.colors.blueberry};
+	text-transform: capitalize;
+	font-family: ${(props) => props.theme.fonts.bold};
+`;
+
+export default ShortingStats;

--- a/sections/shorting/ShortingStats/index.ts
+++ b/sections/shorting/ShortingStats/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ShortingStats';

--- a/styles/common.tsx
+++ b/styles/common.tsx
@@ -1,7 +1,7 @@
 import Tippy from '@tippyjs/react';
 import Button from 'components/Button';
 import NumericInput from 'components/Input/NumericInput';
-import { zIndex } from 'constants/ui';
+import { SPACING_FROM_HEADER, zIndex } from 'constants/ui';
 import styled, { css, keyframes } from 'styled-components';
 
 export const FlexDiv = styled.div`
@@ -267,4 +267,40 @@ export const CenteredMessage = styled.div`
 	text-align: center;
 	display: grid;
 	grid-gap: 10px;
+`;
+
+export const FullHeightContainer = styled(FlexDiv)`
+	justify-content: space-between;
+	width: 100%;
+	flex-grow: 1;
+	height: 100vh;
+	position: relative;
+`;
+
+export const MainContent = styled(FlexDivCol)`
+	flex-grow: 1;
+	max-width: 1000px;
+	position: relative;
+	overflow: auto;
+	margin: ${SPACING_FROM_HEADER} auto 0 auto;
+`;
+
+export const RightSideContent = styled(FlexDivCol)`
+	width: 340px;
+	background-color: ${(props) => props.theme.colors.elderberry};
+	padding: ${SPACING_FROM_HEADER} 0 5px 0;
+	margin-right: -20px;
+	flex-shrink: 0;
+	position: relative;
+	margin-left: 20px;
+	height: 100%;
+`;
+
+export const Table = styled.table.attrs({
+	cellSpacing: 0,
+	cellPadding: 0,
+})`
+	width: 100%;
+	border-collapse: collapse;
+	border: 0;
 `;

--- a/translations/en.json
+++ b/translations/en.json
@@ -324,6 +324,15 @@
 			"safeMax": "safe max",
 			"highRisk": "high risk"
 		},
+		"stats": {
+			"title": "Shorting statistics",
+			"table": {
+				"asset": "asset",
+				"apr": "APR",
+				"open-interest": "open interest",
+				"total": "total"
+			}
+		},
 		"rewards": {
 			"title": "Short <0>{{currencyKey}}</0> Rewards",
 			"button": {

--- a/utils/formatters/date.ts
+++ b/utils/formatters/date.ts
@@ -1,4 +1,5 @@
 import format from 'date-fns/format';
+import getISOWeeksInYear from 'date-fns/getISOWeeksInYear';
 
 import { strPadLeft } from './string';
 
@@ -18,3 +19,5 @@ export const secondsToTime = (seconds: number) => {
 
 	return `${strPadLeft(minutes, '0', 2)}:${strPadLeft(secondsLeft, '0', 2)}`;
 };
+
+export const WEEKS_IN_YEAR = getISOWeeksInYear(new Date());


### PR DESCRIPTION
This PR adds shorting stats and also generalizes the "right side content" for the various pages.
Zoe redesigned the claim functionality too (which will live on the "right side") - will be added in a new PR.

<img width="1535" alt="Screen Shot 2021-03-12 at 10 27 55 pm" src="https://user-images.githubusercontent.com/254095/110934519-369a4880-8382-11eb-909d-e688d7c89a82.png">
