### PR TITLE
refactor(shorting): Move shorting rewards to sit along with stats and match to new design

### DIFF
--- a/components/Button/Button.tsx
+++ b/components/Button/Button.tsx
@@ -30,12 +30,14 @@ const Button = styled.button<ButtonProps>`
 		props.size === 'sm' &&
 		css`
 			height: 24px;
+			line-height: 24px;
 		`}
 
 	${(props) =>
 		props.size === 'md' &&
 		css`
 			height: 32px;
+			line-height: 32px;
 		`}
 
 	${(props) =>
@@ -43,6 +45,7 @@ const Button = styled.button<ButtonProps>`
 		css`
 			padding: 0 40px;
 			height: 40px;
+			line-height: 40px;
 		`}		
 
 
@@ -50,6 +53,7 @@ const Button = styled.button<ButtonProps>`
 		props.size === 'xl' &&
 		css`
 			height: 48px;
+			line-height: 48px;
 		`}				
 
 	${(props) =>

--- a/pages/shorting/index.tsx
+++ b/pages/shorting/index.tsx
@@ -8,18 +8,10 @@ import ShortingCard from 'sections/shorting/ShortingCard';
 import ShortingHistory from 'sections/shorting/ShortingHistory';
 import ShortingRewards from 'sections/shorting/ShortingRewards';
 import ShortingStats from 'sections/shorting/ShortingStats';
-import { SYNTHS_TO_SHORT } from 'sections/shorting/constants';
 
 import AppLayout from 'sections/shared/Layout/AppLayout';
 
-import {
-	GridDiv,
-	PageContent,
-	MainContent,
-	RightSideContent,
-	FullHeightContainer,
-} from 'styles/common';
-import media from 'styles/media';
+import { PageContent, MainContent, RightSideContent, FullHeightContainer } from 'styles/common';
 
 import { DesktopOnlyView } from 'components/Media';
 
@@ -39,15 +31,11 @@ const Shorting: FC = () => {
 					<FullHeightContainer>
 						<MainContent>
 							<ShortingCard />
-							<ShortingRewardsContainer>
-								{SYNTHS_TO_SHORT.map((currencyKey) => (
-									<ShortingRewards key={currencyKey} currencyKey={currencyKey} />
-								))}
-							</ShortingRewardsContainer>
 							{isWalletConnected && <ShortingHistory />}
 						</MainContent>
 						<DesktopOnlyView>
 							<StyledRightSideContent>
+								<ShortingRewards />
 								<ShortingStats />
 							</StyledRightSideContent>
 						</DesktopOnlyView>
@@ -58,19 +46,12 @@ const Shorting: FC = () => {
 	);
 };
 
-const ShortingRewardsContainer = styled(GridDiv)`
-	grid-gap: 24px;
-	grid-auto-flow: column;
-	${media.lessThan('md')`
-		grid-auto-flow: row;
-		/* TODO: this is kinda ugly, and basically undoing the spacing that comes from the TradeSummaryCard */
-		margin-top: -62px;
-	`}
-`;
-
 const StyledRightSideContent = styled(RightSideContent)`
 	padding-left: 32px;
 	padding-right: 32px;
+	> * + * {
+		margin-top: 50px;
+	}
 `;
 
 export default Shorting;

--- a/sections/shorting/ShortingCard/ShortingCard.tsx
+++ b/sections/shorting/ShortingCard/ShortingCard.tsx
@@ -34,6 +34,10 @@ const ShortingCard: FC = () => {
 const Container = styled.div`
 	position: relative;
 	margin-bottom: 30px;
+	${media.lessThan('md')`
+		// TODO: this is needed to cancel the content "push" that comes content from "TradeSummaryCard" (on tablet/mobile)
+		margin-bottom: -50px;
+	`}
 `;
 
 const ConvertContainer = styled.div``;

--- a/sections/shorting/ShortingHistory/ShortingHistory.tsx
+++ b/sections/shorting/ShortingHistory/ShortingHistory.tsx
@@ -16,6 +16,8 @@ import useShortHistoryQuery from 'queries/collateral/subgraph/useShortHistoryQue
 
 import ShortingHistoryTable from './ShortingHistoryTable';
 
+import { Title } from '../common';
+
 import { SYNTHS_TO_SHORT } from '../constants';
 
 const ShortingHistory: FC = () => {
@@ -131,6 +133,7 @@ const ShortingHistory: FC = () => {
 
 	return (
 		<>
+			<Title>{t('shorting.history.title')}</Title>
 			<Filters>
 				<Select
 					inputId="synth-filter-list"
@@ -178,7 +181,8 @@ const ShortingHistory: FC = () => {
 const Filters = styled(GridDiv)`
 	grid-template-columns: repeat(3, 1fr);
 	grid-gap: 18px;
-	margin-top: 30px;
+	border-top: 1px solid ${(props) => props.theme.colors.navy};
+	padding-top: 15px;
 `;
 
 export default ShortingHistory;

--- a/sections/shorting/ShortingRewards/ShortingRewardRow.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewardRow.tsx
@@ -1,0 +1,214 @@
+import { FC, useMemo, useState, useEffect, useCallback, Dispatch, SetStateAction } from 'react';
+import styled from 'styled-components';
+import { useTranslation } from 'react-i18next';
+import { useRecoilValue } from 'recoil';
+import { ethers } from 'ethers';
+
+import Notify from 'containers/Notify';
+import Connector from 'containers/Connector';
+
+import synthetix from 'lib/synthetix';
+import Button from 'components/Button';
+import { normalizeGasLimit, gasPriceInWei } from 'utils/network';
+import TxConfirmationModal from 'sections/shared/modals/TxConfirmationModal';
+
+import { FlexDivCentered, FlexDivRowCentered } from 'styles/common';
+
+import { walletAddressState } from 'store/wallet';
+import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
+import { formatCryptoCurrency } from 'utils/formatters/number';
+
+import { CRYPTO_CURRENCY_MAP } from 'constants/currency';
+import { CurrencyKey } from 'constants/currency';
+
+import useCollateralShortRewards from 'queries/collateral/useCollateralShortRewards';
+import Card from 'components/Card';
+import Currency from 'components/Currency';
+
+type ShortingRewardRowProps = {
+	currencyKey: CurrencyKey;
+	gasPrice: number | null;
+	setGasLimit: Dispatch<SetStateAction<number | null>>;
+	snxPriceRate: number;
+};
+
+const ShortingRewardRow: FC<ShortingRewardRowProps> = ({
+	currencyKey,
+	gasPrice,
+	setGasLimit,
+	snxPriceRate,
+}) => {
+	const { t } = useTranslation();
+
+	const { notify } = Connector.useContainer();
+	const { monitorHash } = Notify.useContainer();
+
+	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+	const [txError, setTxError] = useState<string | null>(null);
+	const walletAddress = useRecoilValue(walletAddressState);
+	const [txConfirmationModalOpen, setTxConfirmationModalOpen] = useState<boolean>(false);
+
+	const { selectPriceCurrencyRate } = useSelectedPriceCurrency();
+	const collateralShortRewardsQuery = useCollateralShortRewards(currencyKey);
+
+	const ShortingRewardRow = useMemo(
+		() =>
+			collateralShortRewardsQuery.isSuccess ? collateralShortRewardsQuery?.data ?? null : null,
+		[collateralShortRewardsQuery.isSuccess, collateralShortRewardsQuery.data]
+	);
+
+	const submissionDisabledReason = useMemo(() => {
+		if (isSubmitting) {
+			return t('shorting.rewards.button.claiming');
+		}
+		if (ShortingRewardRow == null || ShortingRewardRow.lte(0)) {
+			return t('shorting.rewards.button.claim');
+		}
+		return null;
+	}, [ShortingRewardRow, isSubmitting, t]);
+
+	const isSubmissionDisabled = useMemo(() => (submissionDisabledReason != null ? true : false), [
+		submissionDisabledReason,
+	]);
+
+	const totalTradePrice = useMemo(() => {
+		if (ShortingRewardRow != null) {
+			let tradePrice = ShortingRewardRow.multipliedBy(snxPriceRate);
+			if (selectPriceCurrencyRate) {
+				tradePrice = tradePrice.dividedBy(selectPriceCurrencyRate);
+			}
+
+			return tradePrice;
+		}
+		return 0;
+	}, [ShortingRewardRow, snxPriceRate, selectPriceCurrencyRate]);
+
+	const getGasEstimate = useCallback(async () => {
+		if (synthetix.js != null && walletAddress != null) {
+			try {
+				const { CollateralShort } = synthetix.js.contracts;
+
+				const gasLimitEstimate = await CollateralShort.estimateGas.getReward(
+					ethers.utils.formatBytes32String(currencyKey),
+					walletAddress
+				);
+
+				return normalizeGasLimit(Number(gasLimitEstimate));
+			} catch (e) {
+				console.log('gas limit error:', e);
+				return null;
+			}
+		}
+		return null;
+	}, [walletAddress, currencyKey]);
+
+	useEffect(() => {
+		async function getGasEstimateCall() {
+			const newGasLimit = await getGasEstimate();
+			setGasLimit(newGasLimit);
+		}
+		getGasEstimateCall();
+	}, [getGasEstimate, setGasLimit]);
+
+	const onSubmit = async () => {
+		if (synthetix.js != null && gasPrice != null) {
+			setTxError(null);
+			setTxConfirmationModalOpen(true);
+
+			try {
+				setIsSubmitting(true);
+
+				let tx: ethers.ContractTransaction | null = null;
+				const { CollateralShort } = synthetix.js.contracts;
+
+				const gasLimitEstimate = await getGasEstimate();
+
+				setGasLimit(gasLimitEstimate);
+
+				tx = (await CollateralShort.getReward(
+					ethers.utils.formatBytes32String(currencyKey),
+					walletAddress,
+					{
+						gasPrice: gasPriceInWei(gasPrice),
+						gasLimit: gasLimitEstimate,
+					}
+				)) as ethers.ContractTransaction;
+
+				if (tx != null && notify != null) {
+					monitorHash({
+						txHash: tx.hash,
+						onTxConfirmed: () => {
+							collateralShortRewardsQuery.refetch();
+						},
+					});
+				}
+				setTxConfirmationModalOpen(false);
+			} catch (e) {
+				console.log(e);
+				setTxError(e.message);
+			} finally {
+				setIsSubmitting(false);
+			}
+		}
+	};
+
+	return (
+		<StyledCard>
+			<StyledCardBody>
+				<FlexDivRowCentered>
+					<RewardsAmountContainer>
+						<Currency.Icon currencyKey={currencyKey} />
+						<RewardsAmount>
+							{formatCryptoCurrency(ShortingRewardRow ?? 0, {
+								currencyKey: CRYPTO_CURRENCY_MAP.SNX,
+							})}
+						</RewardsAmount>
+					</RewardsAmountContainer>
+					<Button
+						variant="primary"
+						isRounded={true}
+						disabled={isSubmissionDisabled}
+						onClick={onSubmit}
+						size="sm"
+						data-testid="claim-rewards"
+					>
+						{isSubmissionDisabled ? submissionDisabledReason : t('shorting.rewards.button.claim')}
+					</Button>
+				</FlexDivRowCentered>
+			</StyledCardBody>
+			{txConfirmationModalOpen && (
+				<TxConfirmationModal
+					onDismiss={() => setTxConfirmationModalOpen(false)}
+					txError={txError}
+					attemptRetry={onSubmit}
+					baseCurrencyAmount={(ShortingRewardRow ?? 0).toString()}
+					feeAmountInBaseCurrency={null}
+					baseCurrencyKey={CRYPTO_CURRENCY_MAP.SNX}
+					totalTradePrice={totalTradePrice.toString()}
+					txProvider="synthetix"
+					baseCurrencyLabel={t('shorting.rewards.tx-confirm.claiming')}
+				/>
+			)}
+		</StyledCard>
+	);
+};
+
+const StyledCard = styled(Card)`
+	margin-bottom: 16px;
+`;
+
+const StyledCardBody = styled(Card.Body)`
+	padding: 4px ​12px;
+	background: ${(props) => props.theme.colors.navy};
+`;
+
+const RewardsAmount = styled.span`
+	font-family: ${(props) => props.theme.fonts.bold};
+	padding-left: 10px;
+`;
+
+const RewardsAmountContainer = styled(FlexDivCentered)`
+	color: ${(props) => props.theme.colors.white};
+`;
+
+export default ShortingRewardRow;

--- a/sections/shorting/ShortingRewards/ShortingRewardRow.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewardRow.tsx
@@ -110,7 +110,7 @@ const ShortingRewardRow: FC<ShortingRewardRowProps> = ({
 		getGasEstimateCall();
 	}, [getGasEstimate, setGasLimit]);
 
-	const onSubmit = async () => {
+	const handleSubmit = async () => {
 		if (synthetix.js != null && gasPrice != null) {
 			setTxError(null);
 			setTxConfirmationModalOpen(true);
@@ -168,7 +168,7 @@ const ShortingRewardRow: FC<ShortingRewardRowProps> = ({
 						variant="primary"
 						isRounded={true}
 						disabled={isSubmissionDisabled}
-						onClick={onSubmit}
+						onClick={handleSubmit}
 						size="sm"
 						data-testid="claim-rewards"
 					>
@@ -180,7 +180,7 @@ const ShortingRewardRow: FC<ShortingRewardRowProps> = ({
 				<TxConfirmationModal
 					onDismiss={() => setTxConfirmationModalOpen(false)}
 					txError={txError}
-					attemptRetry={onSubmit}
+					attemptRetry={handleSubmit}
 					baseCurrencyAmount={(ShortingRewardRow ?? 0).toString()}
 					feeAmountInBaseCurrency={null}
 					baseCurrencyKey={CRYPTO_CURRENCY_MAP.SNX}

--- a/sections/shorting/ShortingRewards/ShortingRewardRow.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewardRow.tsx
@@ -110,7 +110,7 @@ const ShortingRewardRow: FC<ShortingRewardRowProps> = ({
 		getGasEstimateCall();
 	}, [getGasEstimate, setGasLimit]);
 
-	const handleSubmit = async () => {
+	const handleSubmit = useCallback(async () => {
 		if (synthetix.js != null && gasPrice != null) {
 			setTxError(null);
 			setTxConfirmationModalOpen(true);
@@ -150,7 +150,16 @@ const ShortingRewardRow: FC<ShortingRewardRowProps> = ({
 				setIsSubmitting(false);
 			}
 		}
-	};
+	}, [
+		collateralShortRewardsQuery,
+		currencyKey,
+		gasPrice,
+		getGasEstimate,
+		monitorHash,
+		notify,
+		setGasLimit,
+		walletAddress,
+	]);
 
 	return (
 		<StyledCard>

--- a/sections/shorting/ShortingRewards/ShortingRewards.tsx
+++ b/sections/shorting/ShortingRewards/ShortingRewards.tsx
@@ -1,106 +1,56 @@
-import { FC, useMemo, useState, useEffect, useCallback, ReactNode } from 'react';
+import { FC, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useRecoilState } from 'recoil';
 import styled from 'styled-components';
-import { Trans, useTranslation } from 'react-i18next';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { ethers } from 'ethers';
 
-import Notify from 'containers/Notify';
-import Connector from 'containers/Connector';
+import { gasSpeedState } from 'store/wallet';
 
-import synthetix from 'lib/synthetix';
-import Button from 'components/Button';
-import { normalizeGasLimit, getTransactionPrice, gasPriceInWei } from 'utils/network';
-import { getExchangeRatesForCurrencies } from 'utils/currencies';
-import TxConfirmationModal from 'sections/shared/modals/TxConfirmationModal';
-
-import { GridDivCentered, NoTextTransform } from 'styles/common';
-import media from 'styles/media';
-
-import { gasSpeedState, walletAddressState } from 'store/wallet';
 import useSelectedPriceCurrency from 'hooks/useSelectedPriceCurrency';
-import { formatCryptoCurrency } from 'utils/formatters/number';
 
 import useEthGasPriceQuery from 'queries/network/useEthGasPriceQuery';
 import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 
 import { CRYPTO_CURRENCY_MAP, SYNTHS_MAP } from 'constants/currency';
-import { CurrencyKey } from 'constants/currency';
+import { SYNTHS_TO_SHORT } from '../constants';
+
+import ShortingReward from './ShortingRewardRow';
+
+import { getExchangeRatesForCurrencies } from 'utils/currencies';
+import { getTransactionPrice } from 'utils/network';
 
 import GasPriceSummaryItem from 'sections/exchange/FooterCard/TradeSummaryCard/GasPriceSummaryItem';
 
-import {
-	SummaryItems,
-	SummaryItem,
-	SummaryItemLabel,
-	SummaryItemValue,
-} from 'sections/exchange/FooterCard/common';
+import { Title } from '../common';
 
-import useCollateralShortRewards from 'queries/collateral/useCollateralShortRewards';
-
-type ShortingRewardsProps = {
-	currencyKey: CurrencyKey;
-};
-
-const ShortingRewards: FC<ShortingRewardsProps> = ({ currencyKey }) => {
+const ShortingRewards: FC = () => {
 	const { t } = useTranslation();
-	const [gasSpeed] = useRecoilState(gasSpeedState);
-	const walletAddress = useRecoilValue(walletAddressState);
-	const { selectedPriceCurrency, selectPriceCurrencyRate } = useSelectedPriceCurrency();
-	const [txConfirmationModalOpen, setTxConfirmationModalOpen] = useState<boolean>(false);
-	const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
-	const [txError, setTxError] = useState<string | null>(null);
-	const { notify } = Connector.useContainer();
-	const { monitorHash } = Notify.useContainer();
-	const ethGasPriceQuery = useEthGasPriceQuery();
-	const exchangeRatesQuery = useExchangeRatesQuery();
-	const collateralShortRewardsQuery = useCollateralShortRewards(currencyKey);
-	const shortingRewards = collateralShortRewardsQuery.isSuccess
-		? collateralShortRewardsQuery?.data ?? null
-		: null;
+
 	const [gasLimit, setGasLimit] = useState<number | null>(null);
+	const [gasSpeed] = useRecoilState(gasSpeedState);
 
-	const submissionDisabledReason: ReactNode = useMemo(() => {
-		if (isSubmitting) {
-			return t('shorting.rewards.button.claiming');
-		}
-		if (shortingRewards == null || shortingRewards.lte(0)) {
-			return t('shorting.rewards.button.claim');
-		}
-		return null;
-	}, [shortingRewards, isSubmitting, t]);
+	const ethGasPriceQuery = useEthGasPriceQuery();
+	const { selectedPriceCurrency } = useSelectedPriceCurrency();
+	const exchangeRatesQuery = useExchangeRatesQuery();
 
-	const isSubmissionDisabled = useMemo(() => (submissionDisabledReason != null ? true : false), [
-		submissionDisabledReason,
-	]);
+	const gasPrices = useMemo(
+		() => (ethGasPriceQuery.isSuccess ? ethGasPriceQuery?.data ?? undefined : undefined),
+		[ethGasPriceQuery.isSuccess, ethGasPriceQuery.data]
+	);
 
-	const getGasEstimate = useCallback(async () => {
-		if (synthetix.js != null && walletAddress != null) {
-			try {
-				const gasLimitEstimate = await synthetix.js.contracts.CollateralShort.estimateGas.getReward(
-					ethers.utils.formatBytes32String(currencyKey),
-					walletAddress
-				);
-				return normalizeGasLimit(Number(gasLimitEstimate));
-			} catch (e) {
-				console.log('gas limit error:', e);
-				return null;
-			}
-		}
-		return null;
-	}, [walletAddress, currencyKey]);
+	const gasPrice = useMemo(
+		() =>
+			ethGasPriceQuery.isSuccess
+				? ethGasPriceQuery?.data != null
+					? ethGasPriceQuery.data[gasSpeed]
+					: null
+				: null,
+		[ethGasPriceQuery.isSuccess, ethGasPriceQuery.data, gasSpeed]
+	);
 
-	useEffect(() => {
-		async function getGasEstimateCall() {
-			const newGasLimit = await getGasEstimate();
-			setGasLimit(newGasLimit);
-		}
-		getGasEstimateCall();
-	}, [getGasEstimate]);
-
-	const gasPrices = useMemo(() => ethGasPriceQuery?.data ?? undefined, [ethGasPriceQuery.data]);
-
-	const gasPrice = ethGasPriceQuery?.data != null ? ethGasPriceQuery.data[gasSpeed] : null;
-	const exchangeRates = exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null;
+	const exchangeRates = useMemo(
+		() => (exchangeRatesQuery.isSuccess ? exchangeRatesQuery.data ?? null : null),
+		[exchangeRatesQuery.isSuccess, exchangeRatesQuery.data]
+	);
 
 	const snxPriceRate = useMemo(
 		() =>
@@ -123,132 +73,26 @@ const ShortingRewards: FC<ShortingRewardsProps> = ({ currencyKey }) => {
 		ethPriceRate,
 	]);
 
-	const onSubmit = async () => {
-		if (synthetix.js != null && gasPrice != null) {
-			setTxError(null);
-			setTxConfirmationModalOpen(true);
-
-			try {
-				setIsSubmitting(true);
-
-				let tx: ethers.ContractTransaction | null = null;
-
-				const gasLimitEstimate = await getGasEstimate();
-
-				setGasLimit(gasLimitEstimate);
-
-				tx = (await synthetix.js.contracts.CollateralShort.getReward(
-					ethers.utils.formatBytes32String(currencyKey),
-					walletAddress,
-					{
-						gasPrice: gasPriceInWei(gasPrice),
-						gasLimit: gasLimitEstimate,
-					}
-				)) as ethers.ContractTransaction;
-
-				if (tx != null && notify != null) {
-					monitorHash({
-						txHash: tx.hash,
-						onTxConfirmed: () => {
-							collateralShortRewardsQuery.refetch();
-						},
-					});
-				}
-				setTxConfirmationModalOpen(false);
-			} catch (e) {
-				console.log(e);
-				setTxError(e.message);
-			} finally {
-				setIsSubmitting(false);
-			}
-		}
-	};
-
-	const totalTradePrice = useMemo(() => {
-		if (shortingRewards != null) {
-			let tradePrice = shortingRewards.multipliedBy(snxPriceRate);
-			if (selectPriceCurrencyRate) {
-				tradePrice = tradePrice.dividedBy(selectPriceCurrencyRate);
-			}
-
-			return tradePrice;
-		}
-		return 0;
-	}, [shortingRewards, snxPriceRate, selectPriceCurrencyRate]);
-
 	return (
-		<>
-			<MessageContainer attached={false} className="footer-card">
-				<SummaryItems attached={false}>
-					<StyledSummaryItem>
-						<StyledSummaryItemLabel>
-							<Trans
-								t={t}
-								i18nKey="shorting.rewards.title"
-								values={{ currencyKey }}
-								components={[<NoTextTransform />]}
-							/>
-						</StyledSummaryItemLabel>
-						<BoldSummaryItemValue>
-							{formatCryptoCurrency(shortingRewards ?? 0, { currencyKey: CRYPTO_CURRENCY_MAP.SNX })}
-						</BoldSummaryItemValue>
-					</StyledSummaryItem>
-					<StyledGasPriceSummaryItem gasPrices={gasPrices} transactionFee={transactionFee} />
-				</SummaryItems>
-				<Button
-					variant="primary"
-					isRounded={true}
-					disabled={isSubmissionDisabled}
-					onClick={onSubmit}
-					size="lg"
-					data-testid="claim-rewards"
-				>
-					{isSubmissionDisabled ? submissionDisabledReason : t('shorting.rewards.button.claim')}
-				</Button>
-			</MessageContainer>
-			{txConfirmationModalOpen && (
-				<TxConfirmationModal
-					onDismiss={() => setTxConfirmationModalOpen(false)}
-					txError={txError}
-					attemptRetry={onSubmit}
-					baseCurrencyAmount={(shortingRewards ?? 0).toString()}
-					feeAmountInBaseCurrency={null}
-					baseCurrencyKey={CRYPTO_CURRENCY_MAP.SNX}
-					totalTradePrice={totalTradePrice.toString()}
-					txProvider="synthetix"
-					baseCurrencyLabel={t('shorting.rewards.tx-confirm.claiming')}
+		<div>
+			<Title>{t('shorting.rewards.title')}</Title>
+			{SYNTHS_TO_SHORT.map((currencyKey) => (
+				<ShortingReward
+					key={currencyKey}
+					{...{ gasPrice, setGasLimit, currencyKey, snxPriceRate }}
 				/>
-			)}
-		</>
+			))}
+			<StyledGasPriceSummaryItem {...{ gasPrices, transactionFee }} />
+		</div>
 	);
 };
 
-export const MessageContainer = styled(GridDivCentered)<{ attached?: boolean }>`
-	border-radius: 4px;
-	grid-template-columns: 1fr auto;
-	background-color: ${(props) => props.theme.colors.navy};
-	padding: 16px 32px;
-	${media.lessThan('md')`
-		grid-template-columns: unset;
-		grid-template-rows: 1fr auto;
-		padding: 16px;
-	`}
-`;
-
-const StyledSummaryItemLabel = styled(SummaryItemLabel)`
-	color: ${(props) => props.theme.colors.silver};
-`;
-
-const BoldSummaryItemValue = styled(SummaryItemValue)`
-	font-family: ${(props) => props.theme.fonts.bold};
-`;
-
-const StyledSummaryItem = styled(SummaryItem)`
-	width: 125px;
-`;
-
 const StyledGasPriceSummaryItem = styled(GasPriceSummaryItem)`
-	width: 125px;
+	padding: 5px 0;
+	display: flex;
+	justify-content: space-between;
+	width: auto;
+	border-bottom: 1px solid ${(props) => props.theme.colors.navy};
 `;
 
 export default ShortingRewards;

--- a/sections/shorting/ShortingStats/ShortingStats.tsx
+++ b/sections/shorting/ShortingStats/ShortingStats.tsx
@@ -21,6 +21,8 @@ import { WEEKS_IN_YEAR } from 'utils/formatters/date';
 
 import { SYNTHS_TO_SHORT } from '../constants';
 
+import { Title } from '../common';
+
 const WEEKLY_SNX_REWARDS = toBigNumber(8000);
 
 const ShortingStats = () => {
@@ -69,7 +71,7 @@ const ShortingStats = () => {
 
 	return (
 		<div>
-			<Title>{t('shorting.stats.title')}</Title>
+			<StyledTitle>{t('shorting.stats.title')}</StyledTitle>
 			<Table>
 				<thead>
 					<TableRowHead>
@@ -126,12 +128,8 @@ const ShortingStats = () => {
 	);
 };
 
-const Title = styled.div`
-	color: ${(props) => props.theme.colors.white};
-	font-family: ${(props) => props.theme.fonts.bold};
-	font-size: 14px;
-	text-transform: capitalize;
-	padding-bottom: 5px;
+const StyledTitle = styled(Title)`
+	padding-bottom: 0;
 `;
 
 const TableRow = styled.tr`

--- a/sections/shorting/common.tsx
+++ b/sections/shorting/common.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const Title = styled.div`
+	color: ${(props) => props.theme.colors.white};
+	font-family: ${(props) => props.theme.fonts.bold};
+	font-size: 14px;
+	text-transform: capitalize;
+	padding-bottom: 15px;
+`;

--- a/translations/en.json
+++ b/translations/en.json
@@ -325,7 +325,7 @@
 			"highRisk": "high risk"
 		},
 		"stats": {
-			"title": "Shorting statistics",
+			"title": "shorting statistics",
 			"table": {
 				"asset": "asset",
 				"apr": "APR",
@@ -334,7 +334,7 @@
 			}
 		},
 		"rewards": {
-			"title": "Short <0>{{currencyKey}}</0> Rewards",
+			"title": "available rewards",
 			"button": {
 				"claim": "claim",
 				"claiming": "claiming..."
@@ -344,6 +344,7 @@
 			}
 		},
 		"history": {
+			"title": "your positions",
 			"assets-sort": {
 				"allAssets": "All Assets"
 			},


### PR DESCRIPTION
This PR refactors the shorting rewards and puts them right on the right side (before the stats).

<img width="343" alt="Screen Shot 2021-03-16 at 12 20 30 pm" src="https://user-images.githubusercontent.com/254095/111241844-0ab4e680-8652-11eb-8768-4c11ddbe8991.png">
