### PR TITLE
feat: grab prices from cmc for 1inch convert

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -73,6 +73,9 @@ export const QUERY_KEYS = {
 			networkId: NetworkId
 		) => ['convert', '1inch', quoteCurrencyKey, baseCurrencyKey, amount, networkId],
 	},
+	CMC: {
+		Quotes: (currencyKeys: CurrencyKey[]) => ['cmc', 'quotes', currencyKeys.join('|')],
+	},
 };
 
 export default QUERY_KEYS;

--- a/queries/cmc/useCMCQuotesQuery.ts
+++ b/queries/cmc/useCMCQuotesQuery.ts
@@ -1,0 +1,76 @@
+import axios from 'axios';
+import { QueryConfig, useQuery } from 'react-query';
+import zipObject from 'lodash/zipObject';
+
+import QUERY_KEYS from 'constants/queryKeys';
+import { CurrencyKey } from 'constants/currency';
+
+const CMC_PRICES_API = 'https://coinmarketcap-api.synthetix.io/public/prices?symbols=';
+
+type CMCSymbolQuote = {
+	price: number;
+	volume_24h: number;
+	percent_change_1h: number;
+	percent_change_24h: number;
+	percent_change_7d: number;
+	percent_change_30d: number;
+	market_cap: number;
+	last_updated: string;
+};
+
+type CMCSymbol = {
+	id: number;
+	name: string;
+	symbol: string;
+	slug: string;
+	num_market_pairs: number;
+	date_added: string;
+	tags: string[];
+	max_supply: number;
+	circulating_supply: number;
+	total_supply: number;
+	platform: {
+		id: number;
+		name: string;
+		symbol: string;
+		slug: string;
+		token_address: string;
+	};
+	is_active: number;
+	cmc_rank: number;
+	is_fiat: number;
+	last_updated: string;
+	quote: Record<string, CMCSymbolQuote>;
+};
+
+export type CMCPricesResponse = {
+	status: {
+		credit_count: number;
+		elapsed: number;
+		error_code: number;
+		error_message: string | null;
+		notice: string | null;
+		timestamp: string;
+	};
+	data: Record<CurrencyKey, CMCSymbol>;
+};
+
+const useCMCQuotesQuery = (
+	currencyKeys: CurrencyKey[],
+	options?: QueryConfig<Record<CurrencyKey, CMCSymbolQuote>>
+) => {
+	return useQuery<Record<CurrencyKey, CMCSymbolQuote>>(
+		QUERY_KEYS.CMC.Quotes(currencyKeys),
+		async () => {
+			const response = await axios.get<CMCPricesResponse>(CMC_PRICES_API + currencyKeys.join(','));
+
+			return zipObject(
+				currencyKeys,
+				currencyKeys.map((currencyKey) => response.data.data[currencyKey.toUpperCase()].quote.USD)
+			);
+		},
+		options
+	);
+};
+
+export default useCMCQuotesQuery;


### PR DESCRIPTION
Now ETH/sUSD will get real-world prices using `cmc` api.. (however, the aggressive caching is kinda annoying... so it might not give 100% accurate results).

<img width="1024" alt="Screen Shot 2021-03-23 at 8 28 59 pm" src="https://user-images.githubusercontent.com/254095/112125762-e17af400-8c17-11eb-9acd-44bb7d28b415.png">
