### PR TITLE
fix(CurrencyCard): switch to using padding to not trigger a horizontal scroll

### DIFF
--- a/styles/common.tsx
+++ b/styles/common.tsx
@@ -377,11 +377,14 @@ export const ExchangeCardsWithSelector = styled.div`
 		}
 	}
 	.currency-card-base {
+		.currency-wallet-container {
+			width: 100%;
+		}
 		.currency-card-body {
 			position: relative;
-			left: 30px;
+			padding-left: 61px;
 			${media.lessThan('md')`
-				left: unset;
+				padding-left: 18px;
 			`}
 		}
 	}


### PR DESCRIPTION
Fixes #336 

This problem also exists on the shorting page, so it fixes both. Essentially the "left" CSS prop was making an overflow, so I switched to using padding.