### PR TITLE
fix: ensure trending stats use the correct daily rates

### DIFF
--- a/constants/queryKeys.ts
+++ b/constants/queryKeys.ts
@@ -9,8 +9,8 @@ export const QUERY_KEYS = {
 		HistoricalRates: (currencyKey: CurrencyKey, period: Period) => [
 			'rates',
 			'historicalRates',
-			currencyKey,
 			period,
+			currencyKey,
 		],
 		MarketCap: (currencyKey: CurrencyKey) => ['marketCap', currencyKey],
 		ExchangeRates: ['rates', 'exchangeRates'],

--- a/sections/dashboard/TrendingSynths/TrendingSynths.tsx
+++ b/sections/dashboard/TrendingSynths/TrendingSynths.tsx
@@ -7,7 +7,7 @@ import { useQueryCache } from 'react-query';
 import synthetix, { Synth } from 'lib/synthetix';
 
 import Select from 'components/Select';
-
+import { Period } from 'constants/period';
 import useExchangeRatesQuery from 'queries/rates/useExchangeRatesQuery';
 import useHistoricalVolumeQuery from 'queries/rates/useHistoricalVolumeQuery';
 
@@ -27,7 +27,7 @@ const TrendingSynths: FC = () => {
 
 	const queryCache = useQueryCache();
 
-	const historicalRatesCache = queryCache.getQueries(['rates', 'historicalRates']);
+	const historicalRatesCache = queryCache.getQueries(['rates', 'historicalRates', Period.ONE_DAY]);
 
 	const exchangeRatesQuery = useExchangeRatesQuery();
 	const historicalVolumeQuery = useHistoricalVolumeQuery();

--- a/sections/dashboard/TrendingSynths/utils.ts
+++ b/sections/dashboard/TrendingSynths/utils.ts
@@ -9,8 +9,8 @@ export const toCurrencyKeyMap = (
 	dataField?: string
 ): Record<CurrencyKey, number> =>
 	query.reduce((acc, query) => {
-		// the third item is the currencyKey (according to the queryKeys.ts file)
-		const currencyKey = query.queryKey[2] as string;
+		// the fourth item is the currencyKey (according to the queryKeys.ts file)
+		const currencyKey = query.queryKey[3] as string;
 
 		if (query.state.data != null) {
 			// @ts-ignore


### PR DESCRIPTION
- ensures the trending stats use the correct cached DAILY rates. previously, the rates used were a mix of the different periods (daily, hourly etc).
- fixes https://discord.com/channels/413890591840272394/811367528810020924/853866573349519411