### PR TITLE
fix: downgrade contract interfaces

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@reach/dialog": "0.11.0",
 				"@reach/tabs": "0.11.2",
 				"@synthetixio/assets": "2.0.10",
-				"@synthetixio/contracts-interface": "2.45.3",
+				"@synthetixio/contracts-interface": "2.45.2",
 				"@tippyjs/react": "4.1.0",
 				"axios": "0.21.1",
 				"bignumber.js": "9.0.0",
@@ -55,7 +55,7 @@
 			},
 			"devDependencies": {
 				"@microsoft/eslint-formatter-sarif": "2.1.5",
-				"@svgr/core": "^5.5.0",
+				"@svgr/core": "5.5.0",
 				"@synthetixio/synpress": "0.8.1",
 				"@types/date-fns": "2.6.0",
 				"@types/lodash": "4.14.159",
@@ -4681,14 +4681,754 @@
 			"integrity": "sha512-PshqAnmCGRCXJCxaqP+TlS2MVuwcw1ISx1KdAEz6xuxclvrtcUQ6aRX0iMbkAcbO+YlwPsx9Ct3pOj6QB+qvnw=="
 		},
 		"node_modules/@synthetixio/contracts-interface": {
-			"version": "2.45.3",
-			"resolved": "https://registry.npmjs.org/@synthetixio/contracts-interface/-/contracts-interface-2.45.3.tgz",
-			"integrity": "sha512-MYivQixjYJk9hu+zc6Jiei8iE+nST4erQMU85q1KpiDarXRDi7X2+1QKbTN/T/cqF0D4AqPq7nTHAn+1nweRYw==",
+			"version": "2.45.2",
+			"resolved": "https://registry.npmjs.org/@synthetixio/contracts-interface/-/contracts-interface-2.45.2.tgz",
+			"integrity": "sha512-c27pLIIwNlZiNEAG1gREX8BewDWcr+L37a7+qL2ME7HwsliM5PM3/L3tNOpQ53vW/CacRvBRWLDcbjqp57gk7A==",
 			"dependencies": {
-				"ethers": "5.3.0",
+				"ethers": "5.0.26",
 				"lodash": "4.17.19",
 				"synthetix": "2.45.2",
 				"web3-utils": "1.2.11"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/abi": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.10.tgz",
+			"integrity": "sha512-cfC3lGgotfxX3SMri4+CisOPwignoj/QGHW9J29spC4R4Qqcnk/SYuVkPFBMdLbvBp3f/pGiVqPNwont0TSXhg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/abstract-provider": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
+			"integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/networks": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/web": "^5.0.12"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/abstract-signer": {
+			"version": "5.0.11",
+			"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz",
+			"integrity": "sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/address": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
+			"integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/rlp": "^5.0.7"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/base64": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
+			"integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/basex": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.7.tgz",
+			"integrity": "sha512-OsXnRsujGmYD9LYyJlX+cVe5KfwgLUbUJrJMWdzRWogrygXd5HvGd7ygX1AYjlu1z8W/+t2FoQnczDR/H2iBjA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/bignumber": {
+			"version": "5.0.13",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
+			"integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"bn.js": "^4.4.0"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/bytes": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
+			"integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/constants": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
+			"integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/contracts": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.9.tgz",
+			"integrity": "sha512-CCTxVeDh6sjdSEbjzONhtwPjECvaHE62oGkY8M7kP0CHmgLD2SEGel0HZib8e5oQKRKGly9AKcUFW4g3rQ0AQw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abi": "^5.0.10",
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/hash": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
+			"integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/hdnode": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.8.tgz",
+			"integrity": "sha512-Mscpjd7BBjxYSWghaNMwV0xrBBkOoCq6YEPRm9MgE24CiBlzzbfEB5DGq6hiZqhQaxPkdCUtKKqZi3nt9hx43g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/basex": "^5.0.7",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/pbkdf2": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/wordlists": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/json-wallets": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.10.tgz",
+			"integrity": "sha512-Ux36u+d7Dm0M5AQ+mWuHdvfGPMN8K1aaLQgwzrsD4ELTWlwRuHuQbmn7/GqeOpbfaV6POLwdYcBk2TXjlGp/IQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hdnode": "^5.0.8",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/pbkdf2": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"aes-js": "3.0.0",
+				"scrypt-js": "3.0.1"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/keccak256": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
+			"integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"js-sha3": "0.5.7"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/logger": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+			"integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			]
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/networks": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
+			"integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/pbkdf2": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.7.tgz",
+			"integrity": "sha512-0SNLNixPMqnosH6pyc4yPiUu/C9/Jbu+f6I8GJW9U2qNpMBddmRJviwseoha5Zw1V+Aw0Z/yvYyzIIE8yPXqLA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/sha2": "^5.0.7"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/properties": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
+			"integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/providers": {
+			"version": "5.0.19",
+			"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.19.tgz",
+			"integrity": "sha512-G+flo1jK1y/rvQy6b71+Nu7qOlkOKz+XqpgqFMZslkCzGuzQRmk9Qp7Ln4soK8RSyP1e5TCujaRf1H+EZahoaw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/basex": "^5.0.7",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/networks": "^5.0.7",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/rlp": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/web": "^5.0.12",
+				"bech32": "1.1.4",
+				"ws": "7.2.3"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/random": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.7.tgz",
+			"integrity": "sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/rlp": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
+			"integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/sha2": {
+			"version": "5.0.7",
+			"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.7.tgz",
+			"integrity": "sha512-MbUqz68hhp5RsaZdqi1eg1rrtiqt5wmhRYqdA7MX8swBkzW2KiLgK+Oh25UcWhUhdi1ImU9qrV6if5j0cC7Bxg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"hash.js": "1.1.3"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/signing-key": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
+			"integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"elliptic": "6.5.3"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/solidity": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.8.tgz",
+			"integrity": "sha512-OJkyBq9KaoGsi8E8mYn6LX+vKyCURvxSp0yuGBcOqEFM3vkn9PsCiXsHdOXdNBvlHG5evJXwAYC2UR0TzgJeKA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/sha2": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/strings": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
+			"integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/transactions": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
+			"integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/rlp": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/units": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.9.tgz",
+			"integrity": "sha512-4jIkcMVrJ3lCgXMO4M/2ww0/T/IN08vJTZld7FIAwa6aoBDTAy71+sby3sShl1SG3HEeKYbI3fBWauCUgPRUpQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/constants": "^5.0.8",
+				"@ethersproject/logger": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/wallet": {
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.10.tgz",
+			"integrity": "sha512-5siYr38NhqZKH6DUr6u4PdhgOKur8Q6sw+JID2TitEUmW0tOl8f6rpxAe77tw6SJT60D2UcvgsyLtl32+Nl+ig==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abstract-provider": "^5.0.8",
+				"@ethersproject/abstract-signer": "^5.0.10",
+				"@ethersproject/address": "^5.0.9",
+				"@ethersproject/bignumber": "^5.0.13",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/hdnode": "^5.0.8",
+				"@ethersproject/json-wallets": "^5.0.10",
+				"@ethersproject/keccak256": "^5.0.7",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/random": "^5.0.7",
+				"@ethersproject/signing-key": "^5.0.8",
+				"@ethersproject/transactions": "^5.0.9",
+				"@ethersproject/wordlists": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/web": {
+			"version": "5.0.12",
+			"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
+			"integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/base64": "^5.0.7",
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/@ethersproject/wordlists": {
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.8.tgz",
+			"integrity": "sha512-px2mloc1wAcdTbzv0ZotTx+Uh/dfnDO22D9Rx8xr7+/PUwAhZQjoJ9t7Hn72nsaN83rWBXsLvFcIRZju4GIaEQ==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/bytes": "^5.0.9",
+				"@ethersproject/hash": "^5.0.10",
+				"@ethersproject/logger": "^5.0.8",
+				"@ethersproject/properties": "^5.0.7",
+				"@ethersproject/strings": "^5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/aes-js": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/elliptic": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"dependencies": {
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/ethers": {
+			"version": "5.0.26",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.26.tgz",
+			"integrity": "sha512-MqA8Fvutn3qEW0yBJOHeV6KZmRpF2rqlL2B5058AGkUFsuu6j5Ns/FRlMsbGeQwBz801IB23jQp7vjRfFsKSkg==",
+			"funding": [
+				{
+					"type": "individual",
+					"url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+				},
+				{
+					"type": "individual",
+					"url": "https://www.buymeacoffee.com/ricmoo"
+				}
+			],
+			"dependencies": {
+				"@ethersproject/abi": "5.0.10",
+				"@ethersproject/abstract-provider": "5.0.8",
+				"@ethersproject/abstract-signer": "5.0.11",
+				"@ethersproject/address": "5.0.9",
+				"@ethersproject/base64": "5.0.7",
+				"@ethersproject/basex": "5.0.7",
+				"@ethersproject/bignumber": "5.0.13",
+				"@ethersproject/bytes": "5.0.9",
+				"@ethersproject/constants": "5.0.8",
+				"@ethersproject/contracts": "5.0.9",
+				"@ethersproject/hash": "5.0.10",
+				"@ethersproject/hdnode": "5.0.8",
+				"@ethersproject/json-wallets": "5.0.10",
+				"@ethersproject/keccak256": "5.0.7",
+				"@ethersproject/logger": "5.0.8",
+				"@ethersproject/networks": "5.0.7",
+				"@ethersproject/pbkdf2": "5.0.7",
+				"@ethersproject/properties": "5.0.7",
+				"@ethersproject/providers": "5.0.19",
+				"@ethersproject/random": "5.0.7",
+				"@ethersproject/rlp": "5.0.7",
+				"@ethersproject/sha2": "5.0.7",
+				"@ethersproject/signing-key": "5.0.8",
+				"@ethersproject/solidity": "5.0.8",
+				"@ethersproject/strings": "5.0.8",
+				"@ethersproject/transactions": "5.0.9",
+				"@ethersproject/units": "5.0.9",
+				"@ethersproject/wallet": "5.0.10",
+				"@ethersproject/web": "5.0.12",
+				"@ethersproject/wordlists": "5.0.8"
+			}
+		},
+		"node_modules/@synthetixio/contracts-interface/node_modules/hash.js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
 			}
 		},
 		"node_modules/@synthetixio/contracts-interface/node_modules/lodash": {
@@ -38661,16 +39401,446 @@
 			"integrity": "sha512-PshqAnmCGRCXJCxaqP+TlS2MVuwcw1ISx1KdAEz6xuxclvrtcUQ6aRX0iMbkAcbO+YlwPsx9Ct3pOj6QB+qvnw=="
 		},
 		"@synthetixio/contracts-interface": {
-			"version": "2.45.3",
-			"resolved": "https://registry.npmjs.org/@synthetixio/contracts-interface/-/contracts-interface-2.45.3.tgz",
-			"integrity": "sha512-MYivQixjYJk9hu+zc6Jiei8iE+nST4erQMU85q1KpiDarXRDi7X2+1QKbTN/T/cqF0D4AqPq7nTHAn+1nweRYw==",
+			"version": "2.45.2",
+			"resolved": "https://registry.npmjs.org/@synthetixio/contracts-interface/-/contracts-interface-2.45.2.tgz",
+			"integrity": "sha512-c27pLIIwNlZiNEAG1gREX8BewDWcr+L37a7+qL2ME7HwsliM5PM3/L3tNOpQ53vW/CacRvBRWLDcbjqp57gk7A==",
 			"requires": {
-				"ethers": "5.3.0",
+				"ethers": "5.0.26",
 				"lodash": "4.17.19",
 				"synthetix": "2.45.2",
 				"web3-utils": "1.2.11"
 			},
 			"dependencies": {
+				"@ethersproject/abi": {
+					"version": "5.0.10",
+					"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.10.tgz",
+					"integrity": "sha512-cfC3lGgotfxX3SMri4+CisOPwignoj/QGHW9J29spC4R4Qqcnk/SYuVkPFBMdLbvBp3f/pGiVqPNwont0TSXhg==",
+					"requires": {
+						"@ethersproject/address": "^5.0.9",
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/constants": "^5.0.8",
+						"@ethersproject/hash": "^5.0.10",
+						"@ethersproject/keccak256": "^5.0.7",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/strings": "^5.0.8"
+					}
+				},
+				"@ethersproject/abstract-provider": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.0.8.tgz",
+					"integrity": "sha512-fqJXkewcGdi8LogKMgRyzc/Ls2js07yor7+g9KfPs09uPOcQLg7cc34JN+lk34HH9gg2HU0DIA5797ZR8znkfw==",
+					"requires": {
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/networks": "^5.0.7",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/transactions": "^5.0.9",
+						"@ethersproject/web": "^5.0.12"
+					}
+				},
+				"@ethersproject/abstract-signer": {
+					"version": "5.0.11",
+					"resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.0.11.tgz",
+					"integrity": "sha512-RKOgPSEYafknA62SrD3OCK42AllHE4YBfKYXyQeM+sBP7Nq3X5FpzeoY4uzC43P4wIhmNoTHCKQuwnX7fBqb6Q==",
+					"requires": {
+						"@ethersproject/abstract-provider": "^5.0.8",
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7"
+					}
+				},
+				"@ethersproject/address": {
+					"version": "5.0.9",
+					"resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.0.9.tgz",
+					"integrity": "sha512-gKkmbZDMyGbVjr8nA5P0md1GgESqSGH7ILIrDidPdNXBl4adqbuA3OAuZx/O2oGpL6PtJ9BDa0kHheZ1ToHU3w==",
+					"requires": {
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/keccak256": "^5.0.7",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/rlp": "^5.0.7"
+					}
+				},
+				"@ethersproject/base64": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.0.7.tgz",
+					"integrity": "sha512-S5oh5DVfCo06xwJXT8fQC68mvJfgScTl2AXvbYMsHNfIBTDb084Wx4iA9MNlEReOv6HulkS+gyrUM/j3514rSw==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9"
+					}
+				},
+				"@ethersproject/basex": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/basex/-/basex-5.0.7.tgz",
+					"integrity": "sha512-OsXnRsujGmYD9LYyJlX+cVe5KfwgLUbUJrJMWdzRWogrygXd5HvGd7ygX1AYjlu1z8W/+t2FoQnczDR/H2iBjA==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/properties": "^5.0.7"
+					}
+				},
+				"@ethersproject/bignumber": {
+					"version": "5.0.13",
+					"resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.0.13.tgz",
+					"integrity": "sha512-b89bX5li6aK492yuPP5mPgRVgIxxBP7ksaBtKX5QQBsrZTpNOjf/MR4CjcUrAw8g+RQuD6kap9lPjFgY4U1/5A==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8",
+						"bn.js": "^4.4.0"
+					}
+				},
+				"@ethersproject/bytes": {
+					"version": "5.0.9",
+					"resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.0.9.tgz",
+					"integrity": "sha512-k+17ZViDtAugC0s7HM6rdsTWEdIYII4RPCDkPEuxKc6i40Bs+m6tjRAtCECX06wKZnrEoR9pjOJRXHJ/VLoOcA==",
+					"requires": {
+						"@ethersproject/logger": "^5.0.8"
+					}
+				},
+				"@ethersproject/constants": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.0.8.tgz",
+					"integrity": "sha512-sCc73pFBsl59eDfoQR5OCEZCRv5b0iywadunti6MQIr5lt3XpwxK1Iuzd8XSFO02N9jUifvuZRrt0cY0+NBgTg==",
+					"requires": {
+						"@ethersproject/bignumber": "^5.0.13"
+					}
+				},
+				"@ethersproject/contracts": {
+					"version": "5.0.9",
+					"resolved": "https://registry.npmjs.org/@ethersproject/contracts/-/contracts-5.0.9.tgz",
+					"integrity": "sha512-CCTxVeDh6sjdSEbjzONhtwPjECvaHE62oGkY8M7kP0CHmgLD2SEGel0HZib8e5oQKRKGly9AKcUFW4g3rQ0AQw==",
+					"requires": {
+						"@ethersproject/abi": "^5.0.10",
+						"@ethersproject/abstract-provider": "^5.0.8",
+						"@ethersproject/abstract-signer": "^5.0.10",
+						"@ethersproject/address": "^5.0.9",
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/constants": "^5.0.8",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7"
+					}
+				},
+				"@ethersproject/hash": {
+					"version": "5.0.10",
+					"resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.0.10.tgz",
+					"integrity": "sha512-Tf0bvs6YFhw28LuHnhlDWyr0xfcDxSXdwM4TcskeBbmXVSKLv3bJQEEEBFUcRX0fJuslR3gCVySEaSh7vuMx5w==",
+					"requires": {
+						"@ethersproject/abstract-signer": "^5.0.10",
+						"@ethersproject/address": "^5.0.9",
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/keccak256": "^5.0.7",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/strings": "^5.0.8"
+					}
+				},
+				"@ethersproject/hdnode": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/@ethersproject/hdnode/-/hdnode-5.0.8.tgz",
+					"integrity": "sha512-Mscpjd7BBjxYSWghaNMwV0xrBBkOoCq6YEPRm9MgE24CiBlzzbfEB5DGq6hiZqhQaxPkdCUtKKqZi3nt9hx43g==",
+					"requires": {
+						"@ethersproject/abstract-signer": "^5.0.10",
+						"@ethersproject/basex": "^5.0.7",
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/pbkdf2": "^5.0.7",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/sha2": "^5.0.7",
+						"@ethersproject/signing-key": "^5.0.8",
+						"@ethersproject/strings": "^5.0.8",
+						"@ethersproject/transactions": "^5.0.9",
+						"@ethersproject/wordlists": "^5.0.8"
+					}
+				},
+				"@ethersproject/json-wallets": {
+					"version": "5.0.10",
+					"resolved": "https://registry.npmjs.org/@ethersproject/json-wallets/-/json-wallets-5.0.10.tgz",
+					"integrity": "sha512-Ux36u+d7Dm0M5AQ+mWuHdvfGPMN8K1aaLQgwzrsD4ELTWlwRuHuQbmn7/GqeOpbfaV6POLwdYcBk2TXjlGp/IQ==",
+					"requires": {
+						"@ethersproject/abstract-signer": "^5.0.10",
+						"@ethersproject/address": "^5.0.9",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/hdnode": "^5.0.8",
+						"@ethersproject/keccak256": "^5.0.7",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/pbkdf2": "^5.0.7",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/random": "^5.0.7",
+						"@ethersproject/strings": "^5.0.8",
+						"@ethersproject/transactions": "^5.0.9",
+						"aes-js": "3.0.0",
+						"scrypt-js": "3.0.1"
+					}
+				},
+				"@ethersproject/keccak256": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.0.7.tgz",
+					"integrity": "sha512-zpUBmofWvx9PGfc7IICobgFQSgNmTOGTGLUxSYqZzY/T+b4y/2o5eqf/GGmD7qnTGzKQ42YlLNo+LeDP2qe55g==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"js-sha3": "0.5.7"
+					}
+				},
+				"@ethersproject/logger": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.0.8.tgz",
+					"integrity": "sha512-SkJCTaVTnaZ3/ieLF5pVftxGEFX56pTH+f2Slrpv7cU0TNpUZNib84QQdukd++sWUp/S7j5t5NW+WegbXd4U/A=="
+				},
+				"@ethersproject/networks": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.0.7.tgz",
+					"integrity": "sha512-dI14QATndIcUgcCBL1c5vUr/YsI5cCHLN81rF7PU+yS7Xgp2/Rzbr9+YqpC6NBXHFUASjh6GpKqsVMpufAL0BQ==",
+					"requires": {
+						"@ethersproject/logger": "^5.0.8"
+					}
+				},
+				"@ethersproject/pbkdf2": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/pbkdf2/-/pbkdf2-5.0.7.tgz",
+					"integrity": "sha512-0SNLNixPMqnosH6pyc4yPiUu/C9/Jbu+f6I8GJW9U2qNpMBddmRJviwseoha5Zw1V+Aw0Z/yvYyzIIE8yPXqLA==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/sha2": "^5.0.7"
+					}
+				},
+				"@ethersproject/properties": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.0.7.tgz",
+					"integrity": "sha512-812H1Rus2vjw0zbasfDI1GLNPDsoyX1pYqiCgaR1BuyKxUTbwcH1B+214l6VGe1v+F6iEVb7WjIwMjKhb4EUsg==",
+					"requires": {
+						"@ethersproject/logger": "^5.0.8"
+					}
+				},
+				"@ethersproject/providers": {
+					"version": "5.0.19",
+					"resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.0.19.tgz",
+					"integrity": "sha512-G+flo1jK1y/rvQy6b71+Nu7qOlkOKz+XqpgqFMZslkCzGuzQRmk9Qp7Ln4soK8RSyP1e5TCujaRf1H+EZahoaw==",
+					"requires": {
+						"@ethersproject/abstract-provider": "^5.0.8",
+						"@ethersproject/abstract-signer": "^5.0.10",
+						"@ethersproject/address": "^5.0.9",
+						"@ethersproject/basex": "^5.0.7",
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/constants": "^5.0.8",
+						"@ethersproject/hash": "^5.0.10",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/networks": "^5.0.7",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/random": "^5.0.7",
+						"@ethersproject/rlp": "^5.0.7",
+						"@ethersproject/sha2": "^5.0.7",
+						"@ethersproject/strings": "^5.0.8",
+						"@ethersproject/transactions": "^5.0.9",
+						"@ethersproject/web": "^5.0.12",
+						"bech32": "1.1.4",
+						"ws": "7.2.3"
+					}
+				},
+				"@ethersproject/random": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/random/-/random-5.0.7.tgz",
+					"integrity": "sha512-PxSRWwN3s+FH9AWMZU6AcWJsNQ9KzqKV6NgdeKPtxahdDjCuXxTAuzTZNXNRK+qj+Il351UnweAGd+VuZcOAlQ==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8"
+					}
+				},
+				"@ethersproject/rlp": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.0.7.tgz",
+					"integrity": "sha512-ulUTVEuV7PT4jJTPpfhRHK57tkLEDEY9XSYJtrSNHOqdwMvH0z7BM2AKIMq4LVDlnu4YZASdKrkFGEIO712V9w==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8"
+					}
+				},
+				"@ethersproject/sha2": {
+					"version": "5.0.7",
+					"resolved": "https://registry.npmjs.org/@ethersproject/sha2/-/sha2-5.0.7.tgz",
+					"integrity": "sha512-MbUqz68hhp5RsaZdqi1eg1rrtiqt5wmhRYqdA7MX8swBkzW2KiLgK+Oh25UcWhUhdi1ImU9qrV6if5j0cC7Bxg==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8",
+						"hash.js": "1.1.3"
+					}
+				},
+				"@ethersproject/signing-key": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.0.8.tgz",
+					"integrity": "sha512-YKxQM45eDa6WAD+s3QZPdm1uW1MutzVuyoepdRRVmMJ8qkk7iOiIhUkZwqKLNxKzEJijt/82ycuOREc9WBNAKg==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7",
+						"elliptic": "6.5.3"
+					}
+				},
+				"@ethersproject/solidity": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.0.8.tgz",
+					"integrity": "sha512-OJkyBq9KaoGsi8E8mYn6LX+vKyCURvxSp0yuGBcOqEFM3vkn9PsCiXsHdOXdNBvlHG5evJXwAYC2UR0TzgJeKA==",
+					"requires": {
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/keccak256": "^5.0.7",
+						"@ethersproject/sha2": "^5.0.7",
+						"@ethersproject/strings": "^5.0.8"
+					}
+				},
+				"@ethersproject/strings": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.0.8.tgz",
+					"integrity": "sha512-5IsdXf8tMY8QuHl8vTLnk9ehXDDm6x9FB9S9Og5IA1GYhLe5ZewydXSjlJlsqU2t9HRbfv97OJZV/pX8DVA/Hw==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/constants": "^5.0.8",
+						"@ethersproject/logger": "^5.0.8"
+					}
+				},
+				"@ethersproject/transactions": {
+					"version": "5.0.9",
+					"resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.0.9.tgz",
+					"integrity": "sha512-0Fu1yhdFBkrbMjenEr+39tmDxuHmaw0pe9Jb18XuKoItj7Z3p7+UzdHLr2S/okvHDHYPbZE5gtANDdQ3ZL1nBA==",
+					"requires": {
+						"@ethersproject/address": "^5.0.9",
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/constants": "^5.0.8",
+						"@ethersproject/keccak256": "^5.0.7",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/rlp": "^5.0.7",
+						"@ethersproject/signing-key": "^5.0.8"
+					}
+				},
+				"@ethersproject/units": {
+					"version": "5.0.9",
+					"resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.0.9.tgz",
+					"integrity": "sha512-4jIkcMVrJ3lCgXMO4M/2ww0/T/IN08vJTZld7FIAwa6aoBDTAy71+sby3sShl1SG3HEeKYbI3fBWauCUgPRUpQ==",
+					"requires": {
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/constants": "^5.0.8",
+						"@ethersproject/logger": "^5.0.8"
+					}
+				},
+				"@ethersproject/wallet": {
+					"version": "5.0.10",
+					"resolved": "https://registry.npmjs.org/@ethersproject/wallet/-/wallet-5.0.10.tgz",
+					"integrity": "sha512-5siYr38NhqZKH6DUr6u4PdhgOKur8Q6sw+JID2TitEUmW0tOl8f6rpxAe77tw6SJT60D2UcvgsyLtl32+Nl+ig==",
+					"requires": {
+						"@ethersproject/abstract-provider": "^5.0.8",
+						"@ethersproject/abstract-signer": "^5.0.10",
+						"@ethersproject/address": "^5.0.9",
+						"@ethersproject/bignumber": "^5.0.13",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/hash": "^5.0.10",
+						"@ethersproject/hdnode": "^5.0.8",
+						"@ethersproject/json-wallets": "^5.0.10",
+						"@ethersproject/keccak256": "^5.0.7",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/random": "^5.0.7",
+						"@ethersproject/signing-key": "^5.0.8",
+						"@ethersproject/transactions": "^5.0.9",
+						"@ethersproject/wordlists": "^5.0.8"
+					}
+				},
+				"@ethersproject/web": {
+					"version": "5.0.12",
+					"resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.0.12.tgz",
+					"integrity": "sha512-gVxS5iW0bgidZ76kr7LsTxj4uzN5XpCLzvZrLp8TP+4YgxHfCeetFyQkRPgBEAJdNrexdSBayvyJvzGvOq0O8g==",
+					"requires": {
+						"@ethersproject/base64": "^5.0.7",
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/strings": "^5.0.8"
+					}
+				},
+				"@ethersproject/wordlists": {
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/@ethersproject/wordlists/-/wordlists-5.0.8.tgz",
+					"integrity": "sha512-px2mloc1wAcdTbzv0ZotTx+Uh/dfnDO22D9Rx8xr7+/PUwAhZQjoJ9t7Hn72nsaN83rWBXsLvFcIRZju4GIaEQ==",
+					"requires": {
+						"@ethersproject/bytes": "^5.0.9",
+						"@ethersproject/hash": "^5.0.10",
+						"@ethersproject/logger": "^5.0.8",
+						"@ethersproject/properties": "^5.0.7",
+						"@ethersproject/strings": "^5.0.8"
+					}
+				},
+				"aes-js": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+					"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+				},
+				"elliptic": {
+					"version": "6.5.3",
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+					"requires": {
+						"bn.js": "^4.4.0",
+						"brorand": "^1.0.1",
+						"hash.js": "^1.0.0",
+						"hmac-drbg": "^1.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0",
+						"minimalistic-crypto-utils": "^1.0.0"
+					}
+				},
+				"ethers": {
+					"version": "5.0.26",
+					"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.26.tgz",
+					"integrity": "sha512-MqA8Fvutn3qEW0yBJOHeV6KZmRpF2rqlL2B5058AGkUFsuu6j5Ns/FRlMsbGeQwBz801IB23jQp7vjRfFsKSkg==",
+					"requires": {
+						"@ethersproject/abi": "5.0.10",
+						"@ethersproject/abstract-provider": "5.0.8",
+						"@ethersproject/abstract-signer": "5.0.11",
+						"@ethersproject/address": "5.0.9",
+						"@ethersproject/base64": "5.0.7",
+						"@ethersproject/basex": "5.0.7",
+						"@ethersproject/bignumber": "5.0.13",
+						"@ethersproject/bytes": "5.0.9",
+						"@ethersproject/constants": "5.0.8",
+						"@ethersproject/contracts": "5.0.9",
+						"@ethersproject/hash": "5.0.10",
+						"@ethersproject/hdnode": "5.0.8",
+						"@ethersproject/json-wallets": "5.0.10",
+						"@ethersproject/keccak256": "5.0.7",
+						"@ethersproject/logger": "5.0.8",
+						"@ethersproject/networks": "5.0.7",
+						"@ethersproject/pbkdf2": "5.0.7",
+						"@ethersproject/properties": "5.0.7",
+						"@ethersproject/providers": "5.0.19",
+						"@ethersproject/random": "5.0.7",
+						"@ethersproject/rlp": "5.0.7",
+						"@ethersproject/sha2": "5.0.7",
+						"@ethersproject/signing-key": "5.0.8",
+						"@ethersproject/solidity": "5.0.8",
+						"@ethersproject/strings": "5.0.8",
+						"@ethersproject/transactions": "5.0.9",
+						"@ethersproject/units": "5.0.9",
+						"@ethersproject/wallet": "5.0.10",
+						"@ethersproject/web": "5.0.12",
+						"@ethersproject/wordlists": "5.0.8"
+					}
+				},
+				"hash.js": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
 				"lodash": {
 					"version": "4.17.19",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@reach/dialog": "0.11.0",
 		"@reach/tabs": "0.11.2",
 		"@synthetixio/assets": "2.0.10",
-		"@synthetixio/contracts-interface": "2.45.3",
+		"@synthetixio/contracts-interface": "2.45.2",
 		"@tippyjs/react": "4.1.0",
 		"axios": "0.21.1",
 		"bignumber.js": "9.0.0",


### PR DESCRIPTION
Downgrading contract-interfaces to `2.45.2` for now because last working version

![image](https://user-images.githubusercontent.com/4015977/122576483-b8ec7580-d01f-11eb-926a-7139b485e0a5.png)
