### PR TITLE
fix/temporarily disable /_next/static/(.*) file caching

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -42,7 +42,7 @@
 			"headers": [
 				{
 					"key": "Cache-Control",
-					"value": "public, max-age=31536000, immutable"
+					"value": "public, max-age=0, immutable"
 				}
 			]
 		},

--- a/vercel.json
+++ b/vercel.json
@@ -42,7 +42,7 @@
 			"headers": [
 				{
 					"key": "Cache-Control",
-					"value": "public, max-age=0, immutable"
+					"value": "public, max-age=0, must-revalidate"
 				}
 			]
 		},


### PR DESCRIPTION
We're seeing 404's of js chunks in prod, so we're disabling Vercel's caching config for these files in the effort of restoring functionality. Current behavior is nothing happens when a user clicks `Start trading`

![image](https://user-images.githubusercontent.com/16483341/126724771-f51dcd77-53f6-4d29-9fbb-4f04ae6c128e.png)

https://vercel.com/docs/edge-network/caching#static-files
