### PR TITLE
feat: rearranged tokenlist fallbacks to synthetix -> 1inch -> zapper

### DIFF
--- a/components/Currency/CurrencyIcon/CurrencyIcon.tsx
+++ b/components/Currency/CurrencyIcon/CurrencyIcon.tsx
@@ -53,31 +53,7 @@ export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, ...rest
 		...rest,
 	};
 
-	if (
-		ZapperTokenListMap != null &&
-		ZapperTokenListMap[currencyKey] != null &&
-		!firstFallbackError
-	) {
-		return (
-			<TokenIcon
-				src={ZapperTokenListMap[currencyKey].logoURI}
-				onError={() => setFirstFallbackError(true)}
-				{...props}
-			/>
-		);
-	} else if (
-		OneInchTokenListMap != null &&
-		OneInchTokenListMap[currencyKey] != null &&
-		!secondFallbackError
-	) {
-		return (
-			<TokenIcon
-				src={OneInchTokenListMap[currencyKey].logoURI}
-				onError={() => setSecondFallbackError(true)}
-				{...props}
-			/>
-		);
-	} else if (thirdFallbackError) {
+	if (!firstFallbackError) {
 		switch (currencyKey) {
 			case CRYPTO_CURRENCY_MAP.ETH: {
 				return <Img src={ETHIcon} {...props} />;
@@ -93,12 +69,36 @@ export const CurrencyIcon: FC<CurrencyIconProps> = ({ currencyKey, type, ...rest
 								? synthetixTokenListMap[currencyKey].logoURI
 								: getSynthIcon(currencyKey as CurrencyKey)
 						}
-						onError={() => setThirdFallbackError(true)}
+						onError={() => setFirstFallbackError(true)}
 						{...props}
 						alt={currencyKey}
 					/>
 				);
 		}
+	} else if (
+		OneInchTokenListMap != null &&
+		OneInchTokenListMap[currencyKey] != null &&
+		!secondFallbackError
+	) {
+		return (
+			<TokenIcon
+				src={OneInchTokenListMap[currencyKey].logoURI}
+				onError={() => setSecondFallbackError(true)}
+				{...props}
+			/>
+		);
+	} else if (
+		ZapperTokenListMap != null &&
+		ZapperTokenListMap[currencyKey] != null &&
+		!thirdFallbackError
+	) {
+		return (
+			<TokenIcon
+				src={ZapperTokenListMap[currencyKey].logoURI}
+				onError={() => setThirdFallbackError(true)}
+				{...props}
+			/>
+		);
 	} else {
 		return (
 			<Placeholder style={{ width: props.width, height: props.height }}>{currencyKey}</Placeholder>


### PR DESCRIPTION
We were using older icons for some synths

fixes https://github.com/Kwenta/issues/issues/18

<img src="https://user-images.githubusercontent.com/4015977/127716984-6ea73c8d-5ebc-4a44-bf0b-965d0cc246ec.png" height="700px"/>
