### PR TITLE
config: add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false
+
+[COMMIT_EDITMSG]
+max_line_length = 0


### PR DESCRIPTION
Adding an .editorconfig file would help to keep consistency accros multiple IDEs. I pasted the React's .editorconfig file here, but you can customize parameters such as max line length.
source:https://github.com/facebook/react/blob/main/.editorconfig
